### PR TITLE
ycl kernel with tiling

### DIFF
--- a/PBR/Space/space.cpp
+++ b/PBR/Space/space.cpp
@@ -68,7 +68,18 @@ Space::~Space(){
 std::vector<fungt::Vec3> Space::Render(const int width, const int height) {
   
     std::cout << "Starting render with " << ComputeRender::GetBackendName() << std::endl;
+    size_t triMem = m_triangles.size() * sizeof(Triangle);
+    size_t bvhMem = m_bvh_nodes.size() * sizeof(BVHNode);
+    size_t lightMem = m_lights.size() * sizeof(Light);
+    size_t frameMem = (width*height) * sizeof(fungt::Vec3);
+    size_t totalMem = triMem + bvhMem + lightMem + frameMem;
 
+    std::cout << "Memory usage:\n"
+        << "  Triangles: " << triMem / (1024.0 * 1024.0) << " MB\n"
+        << "  BVH nodes: " << bvhMem / (1024.0 * 1024.0) << " MB\n"
+        << "  Lights:    " << lightMem / (1024.0 * 1024.0) << " MB\n"
+        << "  Framebuffer: " << frameMem / (1024.0 * 1024.0) << " MB\n"
+        << "  Total:     " << totalMem / (1024.0 * 1024.0) << " MB\n";
     std::vector<fungt::Vec3> frameBuffer = m_computeRenderer->RenderScene(
         width, height, m_triangles, m_bvh_nodes, m_lights, m_camera, m_samplesPerPixel
     );

--- a/Samples/viewport/main.cpp
+++ b/Samples/viewport/main.cpp
@@ -9,7 +9,7 @@ int main (){
     //Path to your shaders and models:
     ModelPaths model_ball;
     //model.path   = getAssetPath("Animations/monster_dancing/monster_dancing.dae");
-    model_ball.path = getAssetPath("Obj/Woody/woody-head.obj");
+    model_ball.path = getAssetPath("Obj/LuxoLamp/Luxo.obj");
 
     //Creates a FunGT Scene to display 
     FunGTScene myGame = FunGT::createScene(SCREEN_WIDTH, SCREEN_HEIGHT);


### PR DESCRIPTION
###  Description

This PR implements tiled rendering for the SYCL path tracer to prevent system freezes on integrated GPUs. Instead of dispatching a single kernel for the entire image, the renderer now processes the image in 64x64 tiles with a synchronization point between each tile. This allows the GPU scheduler to handle system tasks between kernel dispatches, keeping the system responsive during renders. Also adds memory usage logging and fixes a USM memory leak by adding the missing free calls.




```console
Starting render with SYCL
Memory usage:
  Triangles: 15.6233 MB
  BVH nodes: 2.49996 MB
  Lights:    2.67029e-05 MB
  Framebuffer: 23.7305 MB
  Total:     41.8537 MB
SYCL_Renderer: Rendering 1920x1080 with 269 samples


========== RENDER COMPLETE ==========
Time: 10 seconds
Output: SYCL_output.png
====================================



```