### PR TITLE
Showing material names in the GUI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -83,7 +83,7 @@
         "__hash_table": "cpp",
         "__tree": "cpp"
     },
-    "cmake.sourceDirectory": "/home/juanchuletas/Documents/Development/FunGT/main",
+    "cmake.sourceDirectory": "/home/juanchuletas/Documents/Development/FunGT",
     "editor.formatOnPaste": true,
     "C_Cpp.errorSquiggles": "disabled"
 }

--- a/GUI/material_editor_window.hpp
+++ b/GUI/material_editor_window.hpp
@@ -88,11 +88,18 @@ public:
         if (meshes.size() > 1) {
             ImGui::Text("Mesh:");
             ImGui::SameLine();
-            if (ImGui::BeginCombo("##MeshSelect",
-                ("Mesh " + std::to_string(m_selectedMeshIndex)).c_str())) {
+            // Get current mesh name for combo preview
+            std::string currentMeshName = meshes[m_selectedMeshIndex]->m_name.empty()
+                ? "Mesh " + std::to_string(m_selectedMeshIndex)
+                : meshes[m_selectedMeshIndex]->m_name;
+            if (ImGui::BeginCombo("##MeshSelect", currentMeshName.c_str())) {
                 for (int i = 0; i < meshes.size(); i++) {
                     bool isSelected = (m_selectedMeshIndex == i);
-                    if (ImGui::Selectable(("Mesh " + std::to_string(i)).c_str(), isSelected)) {
+                    // Use mesh name if available, fallback to index
+                    std::string meshLabel = meshes[i]->m_name.empty()
+                        ? "Mesh " + std::to_string(i)
+                        : meshes[i]->m_name;
+                    if (ImGui::Selectable(meshLabel.c_str(), isSelected)) {
                         m_selectedMeshIndex = i;
                     }
                     if (isSelected) {

--- a/Mesh/mesh.hpp
+++ b/Mesh/mesh.hpp
@@ -25,8 +25,9 @@ struct Texture_struct {
 class Mesh {
 
 public:
+    std::string m_name; // Name of the mesh
     std::vector<funGTVERTEX> m_vertex; //An array of vertices
-    std::vector<unsigned int> m_index;// an array of indices 
+    std::vector<unsigned int> m_index;// an array of indices
     std::vector<Texture> m_texture; //An array of texturesç
     std::vector<Material> m_material;
     //unsigned int VAO;


### PR DESCRIPTION
### Description

This PR adds the mesh name to the mesh class. Also shows the mesh name in the GUI in order to edit the materials easily by selecting the mesh name
