### PR TITLE
Using model matrix to transalate objects in the render scene

### DIFF
--- a/Geometries/cube.cpp
+++ b/Geometries/cube.cpp
@@ -106,7 +106,7 @@ void Cube::setData()
     this->set(vertices,nOfvertices);
 }
 
-glm::mat4 Cube::getModelMatrix()
+glm::mat4 Cube::getModelMatrix() const
 {
     return this->m_ShapeModelMatrix;
 }

--- a/Geometries/cube.hpp
+++ b/Geometries/cube.hpp
@@ -13,7 +13,7 @@ class Cube : public Primitive {
         void create(const std::string &pathToTexture) override; 
         void draw() override ;
         void setData() override;
-        glm::mat4 getModelMatrix() override; 
+        glm::mat4 getModelMatrix() const override; 
         void setPosition(glm::vec3 pos) override; 
         void setModelMatrix() override;
         void updateModelMatrix(float zrot) override;

--- a/Geometries/inf_grid.hpp
+++ b/Geometries/inf_grid.hpp
@@ -30,7 +30,7 @@ public:
     glm::mat4 getViewMatrix() override {
         return m_viewMatrix;
     }
-    glm::mat4 getModelMatrix() override {
+    glm::mat4 getModelMatrix() const override {
         return glm::mat4(1.0f);  // ← Identity = no transformation
     }
     void setProjectionMatrix(const glm::mat4& projMatrix) {

--- a/Geometries/plane.cpp
+++ b/Geometries/plane.cpp
@@ -96,7 +96,7 @@ void Plane::setData()
     unsigned nOfIndices = sizeof(indices)/sizeof(GLuint);
     this->set(vertices,nOfvertices);
 }
-glm::mat4 Plane::getModelMatrix()
+glm::mat4 Plane::getModelMatrix() const
 {
     return this->m_ShapeModelMatrix;
 }

--- a/Geometries/plane.hpp
+++ b/Geometries/plane.hpp
@@ -14,7 +14,7 @@ public:
         void create(const std::string &pathToTexture) override; 
         void draw() override ;
         void setData() override;
-        glm::mat4 getModelMatrix() override; 
+        glm::mat4 getModelMatrix() const override; 
         void setPosition(glm::vec3 pos) override; 
         void setModelMatrix() override;
         void updateModelMatrix(float zrot) override;

--- a/Geometries/primitives.hpp
+++ b/Geometries/primitives.hpp
@@ -55,7 +55,7 @@ public:
         virtual void setData() = 0;
         virtual void create(const std::string &pathToTexture) = 0;
         virtual void draw() = 0;
-        virtual glm::mat4 getModelMatrix() = 0;
+        virtual glm::mat4 getModelMatrix() const = 0;
         virtual void setPosition(glm::vec3 pos) = 0;   //Position 
         virtual void setModelMatrix() = 0;
         virtual void updateModelMatrix(float zrot) = 0;

--- a/Geometries/pyramid.cpp
+++ b/Geometries/pyramid.cpp
@@ -78,7 +78,7 @@ void Pyramid::setData()
     this->set(vertices,nOfvertices);
 }
 
-glm::mat4 Pyramid::getModelMatrix()
+glm::mat4 Pyramid::getModelMatrix() const
 {
      return this->m_ShapeModelMatrix;
 }

--- a/Geometries/pyramid.hpp
+++ b/Geometries/pyramid.hpp
@@ -16,7 +16,7 @@ public:
     void draw() override;
     void create(const std::string &path) override; 
     void setData() override;
-    glm::mat4 getModelMatrix() override; 
+    glm::mat4 getModelMatrix() const override; 
     void setPosition(glm::vec3 pos) override; 
     void setModelMatrix() override;
     void updateModelMatrix(float zrot) override;    

--- a/ParticleSimulation/particle_simulation.cpp
+++ b/ParticleSimulation/particle_simulation.cpp
@@ -99,7 +99,7 @@ void ParticleSimulation::updateModelMatrix()
     m_ModelMatrix = glm::rotate(m_ModelMatrix, glm::radians(m_rotation.z), glm::vec3(0.f, 0.f, 1.f));
     m_ModelMatrix = glm::scale(m_ModelMatrix, m_scale);
 }
-glm::mat4 ParticleSimulation::getModelMatrix()
+glm::mat4 ParticleSimulation::getModelMatrix() const
 {
     return m_ModelMatrix;
 }

--- a/ParticleSimulation/particle_simulation.hpp
+++ b/ParticleSimulation/particle_simulation.hpp
@@ -47,7 +47,7 @@ class ParticleSimulation : public Renderable {
         void setViewMatrix(const glm::mat4 &viewMatrix) override;
         glm::mat4 getViewMatrix() override;
         void updateModelMatrix() override;
-        glm::mat4 getModelMatrix() override;
+        glm::mat4 getModelMatrix() const override;
         
 
 

--- a/Physics/Clothing/clothing.cpp
+++ b/Physics/Clothing/clothing.cpp
@@ -314,7 +314,7 @@ void Clothing::updateModelMatrix()
     m_ModelMatrix = glm::scale(m_ModelMatrix, m_scale);
 }
 
-glm::mat4 Clothing::getModelMatrix()
+glm::mat4 Clothing::getModelMatrix() const
 {
     return m_ModelMatrix;
 }

--- a/Physics/Clothing/clothing.hpp
+++ b/Physics/Clothing/clothing.hpp
@@ -69,7 +69,7 @@ class Clothing : public Renderable
         void setViewMatrix(const glm::mat4 &viewMatrix) override;
         glm::mat4 getViewMatrix() override;
         void updateModelMatrix() override;
-        glm::mat4 getModelMatrix() override;
+        glm::mat4 getModelMatrix() const override;
 
 
 

--- a/Renderable/renderable.hpp
+++ b/Renderable/renderable.hpp
@@ -12,7 +12,7 @@ class Renderable{ //Abstract class
         //Pure virtual functions
         virtual void draw() = 0;
         virtual Shader& getShader() = 0;
-        virtual glm::mat4 getModelMatrix(){
+        virtual glm::mat4 getModelMatrix() const {
             return glm::mat4(0.0);
         }
         virtual void updateModelMatrix(){

--- a/Samples/viewport/main.cpp
+++ b/Samples/viewport/main.cpp
@@ -4,47 +4,50 @@ const unsigned int SCREEN_HEIGHT = 1200;
 
 
 
-int main (){
+int main() {
     //std::string path = findProjectRoot();
     //Path to your shaders and models:
-    ModelPaths model_ball;
-    //model.path   = getAssetPath("Animations/monster_dancing/monster_dancing.dae");
-    model_ball.path = getAssetPath("Obj/LuxoLamp/Luxo.obj");
+    ModelPaths model_ball, model_lamp;
 
+    model_lamp.path = getAssetPath("Obj/LuxoLamp/Luxo.obj");
+    model_ball.path = getAssetPath("Obj/LuxoBall/luxoball.obj");
     //Creates a FunGT Scene to display 
     FunGTScene myGame = FunGT::createScene(SCREEN_WIDTH, SCREEN_HEIGHT);
     //Background color, use 255.f for pure white, 
     myGame->setBackgroundColor();
-    // TEMP: Position camera to see grid
-    //myGame->getCamera().m_vPos = glm::vec3(8.0f, 6.0f, 5.0f);
-    // myGame->getCamera().m_pitch = -25.0f;
-    // myGame->getCamera().m_yaw = -135.0f;
-    // myGame->getCamera().updateVectors();
+
     //Initializes the Graphics Stuff
     myGame->initGL();
     //Gets an instance of the SceneManager class to render objects
     FunGTSceneManager scene_manager = myGame->getSceneManager();
     // Creates an animation object
+    FunGTSModel pixarLamp = SimpleModel::create();
+
+    // Loads Pixar lamp data
+    pixarLamp->load(model_lamp);
+    pixarLamp->position(0.f, 0.f, 0.f);
+    pixarLamp->rotation(0.f, 0.f, 0.f);
+
     FunGTSModel pixarBall = SimpleModel::create();
 
-    // Loads Pixar ball data
     pixarBall->load(model_ball);
-    pixarBall->position(0.f, 0.f, 0.f);
+    pixarBall->position(0.f, 0.f, 10.f);
     pixarBall->rotation(0.f, 0.f, 0.f);
+    pixarBall->scale(2.3);
 
-    
     //std::string ps_vs = getAssetPath("resources/particle.vs");
     //std::string ps_fs = getAssetPath("resources/particle.fs");
     //std::shared_ptr<ParticleSimulation> pSys = std::make_shared<ParticleSimulation>(10000, ps_vs, ps_fs);
     myGame->set([&]() { // Sets up all the scenes in your game
         // Adds the renderable objects to the SceneManager
                 // Adds the renderable objects to the SceneManager
+        scene_manager->addRenderableObj(pixarLamp);
         scene_manager->addRenderableObj(pixarBall);
-    });
-    myGame->render([&](){
+        });
+    myGame->render([&]() {
 
-    });
+        });
 
-    return 0; 
-    
+    return 0;
+
 }

--- a/SimpleModel/simple_model.cpp
+++ b/SimpleModel/simple_model.cpp
@@ -97,7 +97,7 @@ glm::mat4 SimpleModel::getProjectionMatrix()
     return m_ProjectionMatrix;
 }
 
-glm::mat4 SimpleModel::getModelMatrix()
+glm::mat4 SimpleModel::getModelMatrix() const
 {
     return m_ModelMatrix;
 }

--- a/SimpleModel/simple_model.hpp
+++ b/SimpleModel/simple_model.hpp
@@ -43,7 +43,7 @@ public:
     void setViewMatrix(const glm::mat4 &viewMatrix) override;
     void updateModelMatrix() override;
     glm::mat4 getProjectionMatrix() override;
-    glm::mat4 getModelMatrix() override;
+    glm::mat4 getModelMatrix() const override;
     std::vector<Triangle> getTriangleList();
     const std::vector<std::unique_ptr<Mesh>>& getMeshes() const {
         return m_model->getMeshes();


### PR DESCRIPTION
### Description


Path tracer ignored `position()`, `rotation()`, and `scale()` transformations. All models rendered at origin regardless of viewport placement.

### Solution
Modified `Space::LoadModelToRender()` to apply model matrix transformations to vertex positions and normals before storing geometry for path tracing.

### Result
Path tracer output now matches viewport positioning for all models.

### Files Changed
- `src/core/space.cpp`