### PR TITLE
Removing update particles used from funlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,7 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/SceneManager/scene_manager.cpp
     ${FUNGT_BASE_DIR}/CubeMap/cube_map.cpp
     ${FUNGT_BASE_DIR}/ParticleSimulation/particle_simulation.cpp
+    ${FUNGT_BASE_DIR}/ParticleSimulation/particle_simulation_rtc.cpp
     ${FUNGT_BASE_DIR}/Random/random.cpp
     ${FUNGT_BASE_DIR}/Path_Manager/path_manager.cpp
     ${FUNGT_BASE_DIR}/InfoWindow/infowindow.cpp

--- a/ParticleSimulation/particle.hpp
+++ b/ParticleSimulation/particle.hpp
@@ -1,0 +1,56 @@
+#if !defined(_PARTICLE_H_)
+#define _PARTICLE_H_
+#include <vector>
+namespace fgt
+{
+    template <typename T>
+    struct Particle
+    {
+        T position[3];
+        T velocity[3];
+        T acceleration[3];
+        T mass;
+
+        Particle()
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                position[i] = 0;
+                velocity[i] = 0;
+                acceleration[i] = 0;
+            }
+            mass = 1.0f; // Default mass
+        }
+    };
+    template <typename T>
+    class ParticleSet
+    {
+    public:
+        std::vector<Particle<T>> _particles;
+    public:
+        ParticleSet() {};
+        ParticleSet(std::size_t n) {
+            _particles.resize(n);
+        }
+        void SetNumParticles(std::size_t n)
+        {
+            _particles.resize(n);
+        }
+        void print()
+        {
+            for (std::size_t i = 0; i < _particles.size(); i++)
+            {
+                //std::cout << "Particle " << i << ": ";
+                std::cout << "Position: (" << _particles[i].position[0] << ", " << _particles[i].position[1] << ", " << _particles[i].position[2] << "), ";
+                std::cout << "Velocity: (" << _particles[i].velocity[0] << ", " << _particles[i].velocity[1] << ", " << _particles[i].velocity[2] << "), ";
+                //std::cout << "Acceleration: (" << _particles[i].acceleration[0] << ", " << _particles[i].acceleration[1] << ", " << _particles[i].acceleration[2] << "), ";
+                //std::cout << "Mass: " << _particles[i].mass;
+                std::cout << std::endl;
+            }
+        }
+
+    };
+} // namespace fungt
+
+
+#endif // _PARTICLE_H_

--- a/ParticleSimulation/particle_demos.hpp
+++ b/ParticleSimulation/particle_demos.hpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <funlib/funlib.hpp>
+#include "particle.hpp"
 #include "perlin_noise_gpu.hpp"
 
 #ifndef M_PI
@@ -25,7 +26,7 @@ namespace fgt {
     };
 
     // Update lambdas (GPU-compatible, no std::function)
-    auto spiralExplosionUpdate = [](flib::Particle<float>& p, float dt) {
+    auto spiralExplosionUpdate = [](fgt::Particle<float>& p, float dt) {
         constexpr float central_force_strength = 0.5f;
         constexpr float spiral_speed = 0.5f;
         float distance = std::sqrt(p.position[0] * p.position[0] + p.position[1] * p.position[1]);
@@ -38,7 +39,7 @@ namespace fgt {
         p.position[1] += p.velocity[1] * dt;
         p.position[2] += p.velocity[2] * dt;
     };
-    auto blackHoleUpdate = [](flib::Particle<float>& p, float dt) {
+    auto blackHoleUpdate = [](fgt::Particle<float>& p, float dt) {
         constexpr float gravity = 5.0f;
         constexpr float event_horizon = 0.1f;
         float dx = -p.position[0];
@@ -62,7 +63,7 @@ namespace fgt {
         p.position[2] += p.velocity[2] * dt;
         };
 
-    auto vortexUpdate = [](flib::Particle<float>& p, float dt) {
+    auto vortexUpdate = [](fgt::Particle<float>& p, float dt) {
         constexpr float vortex_strength = 2.0f;
         constexpr float lift_force = 0.3f;
         constexpr float damping = 0.98f;
@@ -80,7 +81,7 @@ namespace fgt {
         p.position[2] += p.velocity[2] * dt;
     };
 
-    auto fireworkUpdate = [](flib::Particle<float>& p, float dt) {
+    auto fireworkUpdate = [](fgt::Particle<float>& p, float dt) {
         constexpr float gravity = -2.0f;
         constexpr float drag = 0.99f;
         p.velocity[2] += gravity * dt;
@@ -92,7 +93,7 @@ namespace fgt {
         p.position[2] += p.velocity[2] * dt;
         };
 
-    auto waveUpdate = [](flib::Particle<float>& p, float dt) {
+    auto waveUpdate = [](fgt::Particle<float>& p, float dt) {
         // Remove static time - just use particle position as time offset
         constexpr float wave_speed = 2.0f;
         constexpr float amplitude = 0.5f;
@@ -106,7 +107,7 @@ namespace fgt {
         p.position[2] += p.velocity[2] * dt;
     };
 
-    auto smokeUpdate = [](flib::Particle<float>& p, float dt) {
+    auto smokeUpdate = [](fgt::Particle<float>& p, float dt) {
         // Remove static time - use particle Z position as time proxy
         constexpr float buoyancy = 0.8f;
         constexpr float drag = 0.98f;
@@ -172,11 +173,11 @@ namespace fgt {
     };
 
     // Init functions (CPU-side, can use std::function)
-    using InitFunc = std::function<void(std::vector<flib::Particle<float>>&)>;
+    using InitFunc = std::function<void(std::vector<fgt::Particle<float>>&)>;
 
     static std::vector<InitFunc> demoInits = {
         // Spiral Explosion
-        [](std::vector<flib::Particle<float>>& particles) {
+        [](std::vector<fgt::Particle<float>>& particles) {
             float radius = 0.5f;
             for (std::size_t i = 0; i < particles.size(); ++i) {
                 float angle = static_cast<float>(rand()) / RAND_MAX * 2.0f * M_PI;
@@ -190,7 +191,7 @@ namespace fgt {
             }
         },
         // Black Hole
-        [](std::vector<flib::Particle<float>>& particles) {
+        [](std::vector<fgt::Particle<float>>& particles) {
             float radius = 3.0f;
             for (std::size_t i = 0; i < particles.size(); ++i) {
                 float theta = static_cast<float>(rand()) / RAND_MAX * 2.0f * M_PI;
@@ -205,7 +206,7 @@ namespace fgt {
             }
         },
         // Vortex
-        [](std::vector<flib::Particle<float>>& particles) {
+        [](std::vector<fgt::Particle<float>>& particles) {
             float radius = 2.0f;
             float height = 3.0f;
             for (std::size_t i = 0; i < particles.size(); ++i) {
@@ -221,7 +222,7 @@ namespace fgt {
             }
         },
         // Firework
-        [](std::vector<flib::Particle<float>>& particles) {
+        [](std::vector<fgt::Particle<float>>& particles) {
             for (std::size_t i = 0; i < particles.size(); ++i) {
                 particles[i].position[0] = 0.0f;
                 particles[i].position[1] = 0.0f;
@@ -235,7 +236,7 @@ namespace fgt {
             }
         },
         // Wave Field
-        [](std::vector<flib::Particle<float>>& particles) {
+        [](std::vector<fgt::Particle<float>>& particles) {
             float grid_size = 4.0f;
             int grid_dim = std::sqrt(particles.size());
             for (std::size_t i = 0; i < particles.size(); ++i) {
@@ -250,7 +251,7 @@ namespace fgt {
             }
         },
         // Smoke Plume
-        [](std::vector<flib::Particle<float>>& particles) {
+        [](std::vector<fgt::Particle<float>>& particles) {
             float radius = 0.3f;
             for (std::size_t i = 0; i < particles.size(); ++i) {
                 float angle = static_cast<float>(rand()) / RAND_MAX * 2.0f * M_PI;

--- a/ParticleSimulation/particle_simulatin_rtc.hpp
+++ b/ParticleSimulation/particle_simulatin_rtc.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include <funlib/funlib.hpp>
+#include <string>
+#include <CL/cl_gl.h>
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+class ParticleRTC {
+public:
+    ParticleRTC(sycl::queue& q);
+
+    // Compile user lambda code
+    bool compileKernel(const std::string& user_code, std::string& error_msg);
+
+    // Execute compiled kernel on particles
+    void execute(int numParticles, unsigned int vbo, float dt);
+
+    // Check if device supports RTC
+    static bool isSupported(const sycl::device& dev);
+
+    bool hasKernel() const { return has_kernel_; }
+
+private:
+    sycl::queue& queue_;
+    sycl::kernel compiled_kernel_;
+    bool has_kernel_ = false;
+};

--- a/ParticleSimulation/particle_simulation.cpp
+++ b/ParticleSimulation/particle_simulation.cpp
@@ -1,6 +1,6 @@
 #include "particle_simulation.hpp"
 
-ParticleSimulation::ParticleSimulation(size_t num, std::string vertex_shader, std::string fragment_shader)
+ParticleSimulation::ParticleSimulation(size_t num, std::string vertex_shader, std::string fragment_shader, bool use_rtc)
 : m_NumParticles{num}{
     // INITIALIZE SYCL WITH GL INTEROP (ParticleSimulation owns this responsibility)
     std::cout << "Initializing SYCL for ParticleSimulation..." << std::endl;
@@ -8,21 +8,67 @@ ParticleSimulation::ParticleSimulation(size_t num, std::string vertex_shader, st
     flib::sycl_handler::create_gl_interop_context("gl_queue"); // replaces that queue's context in-place
     flib::sycl_handler::get_device_info("gl_queue");
     m_pSet.SetNumParticles(m_NumParticles);
-    std::cout<<"Particle system constructor"<<std::endl;
-    std::cout<<"Num particles: "<<m_pSet._particles.size()<<std::endl;
-   
-    loadDemo(4);
-    //Print just the position of the firs 2 particles
-    std::cout << "Particle positions:" << std::endl;
-    for (std::size_t i = 0; i < 2; ++i) {
-        std::cout << "Particle "<< i << ": ("
-                  << m_pSet._particles[i].position[0] << ", "
-                  << m_pSet._particles[i].position[1] << ", "
-                  << m_pSet._particles[i].position[2] << ")" << std::endl;
+    std::cout << "Particle system constructor" << std::endl;
+    std::cout << "Num particles: " << m_pSet._particles.size() << std::endl;
+
+    bool m_useRTC  = use_rtc;
+    bool allowRTC = false;
+    // Try RTC first
+    if(m_useRTC){
+
+        if (ParticleRTC::isSupported()) {
+            m_rtc = std::make_unique<ParticleRTC>();
+            std::cout << "ParticleRTC initialized successfully\n";
+
+            std::string init_code = R"""(
+            float theta = index * 0.061803f;
+            float phi = index * 0.123f;
+            float speed = 2.0f + (index % 100) * 0.01f;
+            
+            p.position[0] = 0.0f;
+            p.position[1] = 0.0f;
+            p.position[2] = 0.0f;
+            
+            p.velocity[0] = speed * sycl::sin(phi) * sycl::cos(theta);
+            p.velocity[1] = speed * sycl::sin(phi) * sycl::sin(theta);
+            p.velocity[2] = speed * sycl::cos(phi);
+        )""";
+
+            std::string update_code = R"""(
+            constexpr float gravity = -2.0f;
+            constexpr float drag = 0.99f;
+            p.velocity[2] += gravity * dt;
+            p.velocity[0] *= drag;
+            p.velocity[1] *= drag;
+            p.velocity[2] *= drag;
+            p.position[0] += p.velocity[0] * dt;
+            p.position[1] += p.velocity[1] * dt;
+            p.position[2] += p.velocity[2] * dt;
+        )""";
+
+            std::string error;
+            bool init_ok = m_rtc->compileInitKernel(init_code, error);
+            bool update_ok = m_rtc->compileKernel(update_code, error);
+
+            if (init_ok && update_ok) {
+                std::cout << "Using RTC path\n";
+                this->initRTC();
+            }
+            else {
+                std::cerr << "RTC compilation failed: " << error << "\n";
+                std::cout << "Falling back to compile-time demos\n";
+            }
+        }
+        else {
+            std::cout << "RTC not supported, using compile-time demos\n";
+        }
     }
-    //m_pSet.print();
-    this->init();
-    m_shader.create(vertex_shader,fragment_shader);
+    else{
+
+        loadDemo(3);
+        this->init();
+    }
+    m_shader.create(vertex_shader, fragment_shader);
 }
 
 void ParticleSimulation::loadDemo(int demo_index)
@@ -33,14 +79,14 @@ void ParticleSimulation::loadDemo(int demo_index)
     }
 
     m_currentDemo = demo_index;
+    
     fgt::demoInits[m_currentDemo](m_pSet._particles);
     // UPLOAD NEW POSITIONS TO GPU VBO!
     m_vbo.bind();
     m_vbo.bufferData(m_pSet._particles.data(),
-        m_pSet._particles.size() * sizeof(flib::Particle<float>),
+        m_pSet._particles.size() * sizeof(fgt::Particle<float>),
         GL_DYNAMIC_DRAW);
     m_vbo.unbind();
-   
     std::cout << "Loaded demo: " << fgt::demoNames[m_currentDemo] << std::endl;
 }
 
@@ -54,13 +100,38 @@ void ParticleSimulation::init()
     m_vao.bind();
 
     m_vbo.bind();
-    //m_vbo.bufferData(m_pSet._particles.data(),m_pSet._particles.size()*sizeof(flib::Particle<float>),GL_DYNAMIC_DRAW);
-    m_vbo.bufferData(m_pSet._particles.data(),m_pSet._particles.size()*sizeof(flib::Particle<float>),GL_DYNAMIC_DRAW); 
+    //m_vbo.bufferData(m_pSet._particles.data(),m_pSet._particles.size()*sizeof(fgt::Particle<float>),GL_DYNAMIC_DRAW);
+    m_vbo.bufferData(m_pSet._particles.data(),m_pSet._particles.size()*sizeof(fgt::Particle<float>),GL_DYNAMIC_DRAW); 
 
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(flib::Particle<float>), (void*)offsetof(flib::Particle<float>, position));
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(fgt::Particle<float>), (void*)offsetof(fgt::Particle<float>, position));
     glEnableVertexAttribArray(0);
 
     m_vao.unbind();
+}
+void ParticleSimulation::initRTC()
+{
+    m_vao.genVAO();
+    m_vbo.genVB();
+
+    m_vao.bind();
+    m_vbo.bind();
+
+    // Allocate empty VBO (no CPU data needed for RTC)
+    m_vbo.bufferData(nullptr,
+        m_pSet._particles.size() * sizeof(fgt::Particle<float>),
+        GL_DYNAMIC_DRAW);
+
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE,
+        sizeof(fgt::Particle<float>),
+        (void*)offsetof(fgt::Particle<float>, position));
+    glEnableVertexAttribArray(0);
+
+    m_vao.unbind();
+
+    // GPU kernel fills the VBO
+    if (m_rtc && m_rtc->hasInitKernel()) {
+        m_rtc->executeInit(m_pSet._particles.size(), m_vbo.getId());
+    }
 }
 void ParticleSimulation::draw()
 {
@@ -106,34 +177,42 @@ glm::mat4 ParticleSimulation::getModelMatrix() const
 void ParticleSimulation::simulation()
 {
     int numParticles = m_pSet._particles.size();
+    // Use RTC kernel if available
+    if (m_rtc && m_rtc->hasKernel()) {
+        // Print BEFORE
+        
+        m_rtc->execute(numParticles, m_vbo.getId(), 0.005f);
+
+        return;
+    }
 
     switch (m_currentDemo) {
     case 0:
-        flib::ParticleSystem<float, decltype(fgt::spiralExplosionUpdate)>::update(
+        fgt::ParticleSystem<float, decltype(fgt::spiralExplosionUpdate)>::update(
             numParticles, m_vbo.getId(), fgt::spiralExplosionUpdate, 0.005f);
         break;
     case 1:
-        flib::ParticleSystem<float, decltype(fgt::blackHoleUpdate)>::update(
+        fgt::ParticleSystem<float, decltype(fgt::blackHoleUpdate)>::update(
             numParticles, m_vbo.getId(), fgt::blackHoleUpdate, 0.005f);
         break;
     case 2:
-        flib::ParticleSystem<float, decltype(fgt::vortexUpdate)>::update(
+        fgt::ParticleSystem<float, decltype(fgt::vortexUpdate)>::update(
             numParticles, m_vbo.getId(), fgt::vortexUpdate, 0.005f);
         break;
     case 3:
-        flib::ParticleSystem<float, decltype(fgt::fireworkUpdate)>::update(
+        fgt::ParticleSystem<float, decltype(fgt::fireworkUpdate)>::update(
             numParticles, m_vbo.getId(), fgt::fireworkUpdate, 0.005f);
         break;
     case 4:
-        flib::ParticleSystem<float, decltype(fgt::waveUpdate)>::update(
+        fgt::ParticleSystem<float, decltype(fgt::waveUpdate)>::update(
             numParticles, m_vbo.getId(), fgt::waveUpdate, 0.005f);
         break;
     case 5:
-        flib::ParticleSystem<float, decltype(fgt::smokeUpdate)>::update(
+        fgt::ParticleSystem<float, decltype(fgt::smokeUpdate)>::update(
             numParticles, m_vbo.getId(), fgt::smokeUpdate, 0.005f);
         break;
     default:
-        flib::ParticleSystem<float, decltype(fgt::spiralExplosionUpdate)>::update(
+        fgt::ParticleSystem<float, decltype(fgt::spiralExplosionUpdate)>::update(
             numParticles, m_vbo.getId(), fgt::spiralExplosionUpdate, 0.005f);
         break;
     }

--- a/ParticleSimulation/particle_simulation.hpp
+++ b/ParticleSimulation/particle_simulation.hpp
@@ -5,10 +5,16 @@
 #include "VertexGL/vertexBuffers.hpp"
 #include "VertexGL/vertexIndices.hpp"
 #include "Shaders/shader.hpp"
+#include "particle.hpp"
 #include "particle_demos.hpp"
-#include <funlib/funlib.hpp>
+#include "particle_system.hpp"
+#include "particle_simulation_rtc.hpp"
+
 class ParticleSimulation : public Renderable {
     
+    //RTC
+    std::unique_ptr<ParticleRTC> m_rtc;
+
     VertexArrayObject m_vao; 
     VertexBuffer m_vbo; 
     Shader m_shader;
@@ -24,12 +30,13 @@ class ParticleSimulation : public Renderable {
     glm::mat4 m_projectionMatrix  = glm::mat4(1.f);
     glm::mat4 m_ModelMatrix = glm::mat4(1.f);
     int m_currentDemo;
+    bool m_useRTC;
     
 
     public:
-        flib::ParticleSet<float> m_pSet;
+        fgt::ParticleSet<float> m_pSet;
 
-        ParticleSimulation(size_t num, std::string vertex_shader, std::string fragment_shader);
+        ParticleSimulation(size_t num, std::string vertex_shader, std::string fragment_shader, bool use_rtc = false);
         float random_between(float min, float max) {
             return min + static_cast<float>(rand()) / RAND_MAX * (max - min);
         }
@@ -39,6 +46,7 @@ class ParticleSimulation : public Renderable {
         void  loadDemo(int index);
 
         void init();
+        void initRTC();
         void simulation();
         //methods from the Renderable class
         void draw() override;
@@ -47,7 +55,7 @@ class ParticleSimulation : public Renderable {
         void setViewMatrix(const glm::mat4 &viewMatrix) override;
         glm::mat4 getViewMatrix() override;
         void updateModelMatrix() override;
-        glm::mat4 getModelMatrix() const override;
+        glm::mat4 getModelMatrix()const override;
         
 
 

--- a/ParticleSimulation/particle_simulation_rtc.cpp
+++ b/ParticleSimulation/particle_simulation_rtc.cpp
@@ -1,0 +1,290 @@
+#include "particle_simulation_rtc.hpp"
+
+ParticleRTC::ParticleRTC() {
+
+}
+
+bool ParticleRTC::compileInitKernel(const std::string& user_init_code, std::string& error_msg)
+{
+    try {
+        sycl::queue queue_ = flib::sycl_handler::get_queue("gl_queue");
+
+        std::string user_header = R"""(
+namespace fgt {
+    template<typename T>
+    struct Particle {
+        T position[3];
+        T velocity[3];
+        T acceleration[3];
+        T mass;
+    };
+}
+
+struct UserInit {
+    void operator()(fgt::Particle<float>& p, int index) const {
+        )""" + user_init_code + R"""(
+    }
+};
+)""";
+
+        static constexpr auto sycl_source = R"""(
+#include <sycl/sycl.hpp>
+#include "user_init.h"
+
+extern "C" SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((
+    sycl::ext::oneapi::experimental::nd_range_kernel<2>))
+void particle_init_kernel(fgt::Particle<float>* particles, int n, int ydim) {
+    auto item = sycl::ext::oneapi::this_work_item::get_nd_item<2>();
+    std::size_t index = item.get_global_id(0) * ydim + item.get_global_id(1);
+    
+    if (index < n) {
+        UserInit init;
+        init(particles[index], index);
+    }
+}
+)""";
+
+        syclexp::include_files includes{ "user_init.h", user_header };
+        auto source_bundle = syclexp::create_kernel_bundle_from_source(
+            queue_.get_context(),
+            syclexp::source_language::sycl,
+            sycl_source,
+            syclexp::properties{ includes }
+        );
+
+        syclexp::build_options opts{ "-fsycl" };
+        std::string compiler_log;
+        syclexp::save_log log{ &compiler_log };
+
+        auto exec_bundle = syclexp::build(source_bundle, syclexp::properties{ opts, log });
+
+        std::cout << "Init Kernel Compiler output:\n" << compiler_log << "\n";
+
+        compiled_init_kernel_ = exec_bundle.ext_oneapi_get_kernel("particle_init_kernel");
+
+        return true;
+
+    }
+    catch (sycl::exception& e) {
+        error_msg = std::string("Init kernel RTC failed: ") + e.what();
+        compiled_init_kernel_.reset();
+        return false;
+    }
+}
+bool ParticleRTC::isSupported() {
+    
+    return flib::sycl_handler::is_rtc_available();
+}
+
+void ParticleRTC::executeInit(int numParticles, unsigned int vbo)
+{
+    if (!compiled_init_kernel_.has_value()) {
+        throw std::runtime_error("No compiled init kernel available");
+    }
+
+    sycl::queue queue_ = flib::sycl_handler::get_queue("gl_queue");
+
+    std::size_t n = static_cast<std::size_t>(numParticles);
+    std::size_t xdim = static_cast<std::size_t>(std::ceil(std::sqrt(n)));
+    std::size_t ydim = xdim;
+
+    sycl::kernel& kernel_ref = compiled_init_kernel_.value();
+
+    // GL interop
+    cl_context clcontext = flib::sycl_handler::get_clContext();
+    cl_command_queue clqueue = sycl::get_native<sycl::backend::opencl>(queue_);
+    cl_mem clbuffer = clCreateFromGLBuffer(clcontext, CL_MEM_READ_WRITE, vbo, NULL);
+
+    glFinish();
+    cl_event acquire_event;
+    clEnqueueAcquireGLObjects(clqueue, 1, &clbuffer, 0, NULL, &acquire_event);
+    clWaitForEvents(1, &acquire_event);
+
+    // Execute init kernel
+    queue_.submit([&](sycl::handler& cgh) {
+        cgh.set_args(clbuffer, static_cast<int>(n), static_cast<int>(ydim));
+        cgh.parallel_for(sycl::nd_range<2>{
+            sycl::range<2>{xdim, ydim},
+                sycl::range<2>{1, 1}
+        }, kernel_ref);
+        });
+    queue_.wait();
+
+    clFinish(clqueue);
+    cl_event release_event;
+    clEnqueueReleaseGLObjects(clqueue, 1, &clbuffer, 0, NULL, &release_event);
+    clWaitForEvents(1, &release_event);
+    glMemoryBarrier(GL_VERTEX_ATTRIB_ARRAY_BARRIER_BIT | GL_BUFFER_UPDATE_BARRIER_BIT);
+    clReleaseMemObject(clbuffer);
+
+    std::cout << "Particles initialized with RTC kernel\n";
+}
+
+bool ParticleRTC::compileKernel(const std::string& user_code, std::string& error_msg) {
+    try {
+        sycl::queue queue_ = flib::sycl_handler::get_queue("gl_queue");
+        std::string user_header = R"""(
+namespace fgt {
+    template<typename T>
+    struct Particle {
+        T position[3];
+        T velocity[3];
+        T acceleration[3];
+        T mass;
+        
+        Particle() {
+            for (int i = 0; i < 3; i++) {
+                position[i] = 0;
+                velocity[i] = 0;
+                acceleration[i] = 0;
+            }
+            mass = 1.0f;
+        }
+    };
+}
+
+struct UserUpdate {
+    void operator()(fgt::Particle<float>& p, float dt) const {
+        )""" + user_code + R"""(
+    }
+};
+)""";
+
+
+        static constexpr auto sycl_source = R"""(
+#include <sycl/sycl.hpp>
+#include "user_update.h"
+
+extern "C" SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((
+    sycl::ext::oneapi::experimental::nd_range_kernel<2>))
+void particle_rtc_kernel(fgt::Particle<float>* particles, int n, int ydim, float dt) {
+    auto item = sycl::ext::oneapi::this_work_item::get_nd_item<2>();
+    std::size_t index = item.get_global_id(0) * ydim + item.get_global_id(1);
+    
+    if (index < n) {
+        UserUpdate update;
+        update(particles[index], dt);
+    }
+}
+)""";
+        
+        syclexp::include_files includes{ "user_update.h", user_header };
+       
+        auto source_bundle = syclexp::create_kernel_bundle_from_source(
+            queue_.get_context(),
+            syclexp::source_language::sycl,
+            sycl_source,
+            syclexp::properties{ includes }
+        );
+
+        syclexp::build_options opts{ "-fsycl" };
+        std::string compiler_log;
+
+        syclexp::save_log log{ &compiler_log };
+
+        auto exec_bundle = syclexp::build(source_bundle, syclexp::properties{ opts,log });
+
+        std::cout << "RTC Compiler output:\n" << compiler_log << "\n";
+
+        compiled_kernel_ = exec_bundle.ext_oneapi_get_kernel("particle_rtc_kernel");
+        has_kernel_ = true;
+
+        return true;
+
+    }
+    catch (sycl::exception& e) {
+        error_msg = std::string("SYCL RTC failed: ") + e.what();
+        has_kernel_ = false;
+        return false;
+    }
+}
+
+void ParticleRTC::execute(int numParticles, unsigned int vbo, float dt) {
+
+    sycl::queue queue_ = flib::sycl_handler::get_queue("gl_queue");
+    if (!compiled_kernel_.has_value()) {
+        throw std::runtime_error("No compiled kernel available");
+    }
+    //std::cout << "[DEBUG] kernel exists\n";
+
+    std::size_t n = static_cast<std::size_t>(numParticles);
+    std::size_t xdim = static_cast<std::size_t>(std::ceil(std::sqrt(n)));
+    std::size_t ydim = xdim;
+    //std::cout << "[DEBUG] n=" << n << " xdim=" << xdim << " ydim=" << ydim << "\n";
+
+    sycl::kernel& kernel_ref = compiled_kernel_.value();
+//    std::cout << "[DEBUG] got kernel ref\n";
+
+    cl_context clcontext = flib::sycl_handler::get_clContext();
+  //  std::cout << "[DEBUG] got cl context\n";
+
+    cl_command_queue clqueue = sycl::get_native<sycl::backend::opencl>(queue_);
+    //std::cout << "[DEBUG] got cl queue\n";
+
+    cl_mem clbuffer = clCreateFromGLBuffer(clcontext, CL_MEM_READ_WRITE, vbo, NULL);
+    //std::cout << "[DEBUG] created cl buffer from GL\n";
+
+    if (clbuffer == NULL) {
+        throw std::runtime_error("Failed to create OpenCL buffer from GL buffer");
+    }
+
+    sycl::context syclCtx = flib::sycl_handler::get_sycl_context();
+   // std::cout << "[DEBUG] got sycl context\n";
+
+    glFinish();
+    //std::cout << "[DEBUG] glFinish done\n";
+
+    cl_event acquire_event;
+    clEnqueueAcquireGLObjects(clqueue, 1, &clbuffer, 0, NULL, &acquire_event);
+   // std::cout << "[DEBUG] acquire enqueued\n";
+
+    clWaitForEvents(1, &acquire_event);
+    //std::cout << "[DEBUG] acquire complete\n";
+
+    {
+      //  std::cout << "[DEBUG] creating buffer\n";
+        // sycl::buffer<fgt::Particle<float>> buf =
+        //     sycl::make_buffer<sycl::backend::opencl, fgt::Particle<float>>(clbuffer, syclCtx);
+        //std::cout << "[DEBUG] buffer created\n";
+
+        queue_.submit([&](sycl::handler& cgh) {
+          //  std::cout << "[DEBUG] in submit lambda\n";
+            //auto acc = buf.template get_access<sycl::access::mode::read_write>(cgh);
+            //std::cout << "[DEBUG] got accessor\n";
+            //auto multi_ptr = acc.template get_multi_ptr<sycl::access::decorated::no>();
+            //auto particles_ptr = multi_ptr.get();
+            
+            cgh.set_args(clbuffer, static_cast<int>(n), static_cast<int>(ydim), dt);
+            //std::cout << "[DEBUG] set args\n";
+            cgh.parallel_for(
+                sycl::nd_range<2>{
+                sycl::range<2>{xdim, ydim},  // global size
+                    sycl::range<2>{1, 1}         // local work-group size
+            },
+                kernel_ref
+            );
+            //std::cout << "[DEBUG] parallel_for submitted\n";
+            });
+        //std::cout << "[DEBUG] submit done\n";
+
+        queue_.wait();
+        //std::cout << "[DEBUG] queue wait done\n";
+    }
+    //std::cout << "[DEBUG] buffer destroyed\n";
+
+    clFinish(clqueue);
+    //std::cout << "[DEBUG] clFinish done\n";
+
+    cl_event release_event;
+    clEnqueueReleaseGLObjects(clqueue, 1, &clbuffer, 0, NULL, &release_event);
+    //std::cout << "[DEBUG] release enqueued\n";
+
+    clWaitForEvents(1, &release_event);
+   // std::cout << "[DEBUG] release complete\n";
+
+    glMemoryBarrier(GL_VERTEX_ATTRIB_ARRAY_BARRIER_BIT | GL_BUFFER_UPDATE_BARRIER_BIT);
+   // std::cout << "[DEBUG] memory barrier done\n";
+
+    clReleaseMemObject(clbuffer);
+    //std::cout << "[DEBUG] execute complete\n";
+}

--- a/ParticleSimulation/particle_simulation_rtc.hpp
+++ b/ParticleSimulation/particle_simulation_rtc.hpp
@@ -1,0 +1,36 @@
+#if !defined(_PARTICLE_SIM_RTC_H_)
+#define _PARTICLE_SIM_RTC_H_
+#include <GL/glew.h>
+#include <funlib/funlib.hpp>
+#include "particle.hpp"
+#include <string>
+#include <optional>
+#include <CL/cl_gl.h>
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+class ParticleRTC {
+public:
+    ParticleRTC();
+
+    bool compileInitKernel(const std::string& user_init_code, std::string& error_msg);
+    void executeInit(int numParticles, unsigned int vbo);
+    // Compile user lambda code
+    bool compileKernel(const std::string& user_code, std::string& error_msg);
+    
+    // Execute compiled kernel on particles
+    void execute(int numParticles, unsigned int vbo, float dt);
+
+    // Check if device supports RTC
+    static bool isSupported();
+
+    bool hasKernel() const { return has_kernel_; }
+    bool hasInitKernel() const { return compiled_init_kernel_.has_value(); }
+
+private:
+    //sycl::queue& queue_;
+    std::optional<sycl::kernel> compiled_kernel_;
+    std::optional<sycl::kernel> compiled_init_kernel_;
+    bool has_kernel_ = false;
+};
+
+#endif // _PARTICLE_SIM_RTC_H_

--- a/ParticleSimulation/particle_system.hpp
+++ b/ParticleSimulation/particle_system.hpp
@@ -1,0 +1,70 @@
+#if !defined(_PARTICLE_SYSTEM_FGT_H)
+#define _PARTICLE_SYSTEM_FGT_H
+#include <funlib/sycl/sycl_handler.hpp>
+#include <vector>
+#include <functional>
+#include <cmath>
+#include "particle.hpp"
+#include <CL/cl_gl.h>
+namespace fgt {
+
+    template <typename T, typename Func>
+    class ParticleSystem
+    {
+        class sycl_handler; // Forward declaration of sycl_handler
+    public:
+        void static update(int numOfParticles, unsigned int vbo, Func update_function, T dt) {
+            std::size_t n = static_cast<std::size_t>(numOfParticles);
+            std::size_t xdim = static_cast<std::size_t>(std::ceil(std::sqrt(n)));
+            std::size_t ydim = xdim;
+            // Get the SYCL queue from the sycl_handler   
+            sycl::queue Q = flib::sycl_handler::get_queue("gl_queue");
+            //OpeCL interop for updating particles
+            cl_context clcontext = flib::sycl_handler::get_clContext();
+
+            cl_command_queue clqueue = sycl::get_native<sycl::backend::opencl>(Q);
+
+            cl_mem clbuffer = clCreateFromGLBuffer(clcontext, CL_MEM_READ_WRITE, vbo, NULL);
+            if (clbuffer == NULL) {
+                throw std::runtime_error("Failed to create OpenCL buffer from GL buffer");
+            }
+            sycl::context syclCtx = flib::sycl_handler::get_sycl_context();
+            // CRITICAL: Finish all pending OpenGL operations first
+            glFinish();
+            cl_event acquire_event;
+            clEnqueueAcquireGLObjects(clqueue, 1, &clbuffer, 0, NULL, &acquire_event);
+            clWaitForEvents(1, &acquire_event);  // Wait for acquisition to complete 
+            {
+                sycl::buffer<Particle<T>> buf =
+                    sycl::make_buffer<sycl::backend::opencl, Particle<T>>(clbuffer, syclCtx);
+
+                Q.submit([&](sycl::handler& cgh) {
+                    auto acc = buf.template get_access<sycl::access::mode::read_write>(cgh);
+                    cgh.parallel_for(sycl::range<2>(sycl::range<2>{static_cast<size_t>(xdim), static_cast<size_t>(ydim)}),
+                        [=](sycl::item<2> item) {
+                            //user defined lambda function
+                            std::size_t index = item[0] * ydim + item[1];
+                            if (index < n) {
+                                update_function(acc[index], dt);
+                            }
+                        });
+
+                    });
+
+                Q.wait();
+            }
+            clFinish(clqueue);
+            //Release OpenCL buffer
+            cl_event release_event;
+            clEnqueueReleaseGLObjects(clqueue, 1, &clbuffer, 0, NULL, &release_event);
+            clWaitForEvents(1, &release_event);  // Wait for release to complete
+
+            glMemoryBarrier(GL_VERTEX_ATTRIB_ARRAY_BARRIER_BIT | GL_BUFFER_UPDATE_BARRIER_BIT);
+            clReleaseMemObject(clbuffer);
+        }
+
+    };
+
+}
+
+#endif // _PARTICLE_SYSTEM_FGT_H

--- a/Samples/particle_simulation/CMakeLists.txt
+++ b/Samples/particle_simulation/CMakeLists.txt
@@ -255,6 +255,7 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/SceneManager/scene_manager.cpp
     ${FUNGT_BASE_DIR}/CubeMap/cube_map.cpp
     ${FUNGT_BASE_DIR}/ParticleSimulation/particle_simulation.cpp
+    ${FUNGT_BASE_DIR}/ParticleSimulation/particle_simulation_rtc.cpp
     ${FUNGT_BASE_DIR}/Random/random.cpp
     ${FUNGT_BASE_DIR}/Path_Manager/path_manager.cpp
     ${FUNGT_BASE_DIR}/InfoWindow/infowindow.cpp


### PR DESCRIPTION
# Pull Request Template

## Description
This PR adds the first stage of the Runtime compilation for particle simulation and solo removes the usage of funlib to perform the update of particles

## Type of Change
<!-- Mark with [x] -->
- [ ]  Bug fix (non-breaking change that fixes an issue)
- [ ]  New feature (non-breaking change that adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)
- [x]  Refactor (code change that neither fixes a bug nor adds a feature)
- [ ]  Documentation (changes to docs only)
- [ ]  Performance (improves performance)

## Changes Made
<!-- List specific changes -->
- 
- 
- 

## Technical Details
<!-- Implementation details, algorithms used, architectural decisions -->

## Testing
<!-- How was this tested? -->
- [ ] Tested locally
- [ ] Visual comparison before/after
- [ ] Performance benchmarked
- [ ] Edge cases verified

## Screenshots / Results
<!-- If applicable, add screenshots or render comparisons -->

| Before | After |
|--------|-------|
|        |       |

## Performance Impact
<!-- If applicable -->
- Render time before: 
- Render time after: 
- Memory usage: 

## Related Issues
<!-- Link related issues -->
Closes #

## Checklist
- [ ] Code compiles without warnings
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my own code
- [ ] Commented hard-to-understand areas
- [ ] No unnecessary debug code left behind

## Notes for Reviewers
<!-- Anything specific reviewers should focus on -->