### PR TITLE
fix: exported rendered image now contains the proper light setup

### DIFF
--- a/GUI/render_action_window.hpp
+++ b/GUI/render_action_window.hpp
@@ -291,6 +291,8 @@ private:
             // ================================================================
             Space space(pbrCam);
             space.InitComputeRenderBackend();
+            // ADD LIGHT FROM THE SceneManager config
+            space.loadLightsFromScene(m_sceneManager->getLights());
             // ================================================================
             // 4. LOAD ALL MODELS FROM SCENE
             // ================================================================


### PR DESCRIPTION
# Pull Request Template

## Description
This PR solve the issue about gizmo configuration lights are not applied to the final render

## Type of Change
<!-- Mark with [x] -->
- [x]  Bug fix (non-breaking change that fixes an issue)
- [ ]  New feature (non-breaking change that adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)
- [ ]  Refactor (code change that neither fixes a bug nor adds a feature)
- [ ]  Documentation (changes to docs only)
- [ ]  Performance (improves performance)

## Changes Made

Render Action window in the GUI folder

## Testing
<!-- How was this tested? -->
- [x] Tested locally
- [x] Visual comparison before/after
- [ ] Performance benchmarked
- [ ] Edge cases verified

