### PR TITLE
Render loop optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,7 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/VertexGL/vertexBuffers.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexIndices.cpp
     ${FUNGT_BASE_DIR}/VertexGL/uniform_buffer_object.cpp
+    ${FUNGT_BASE_DIR}/VertexGL/shaderStorageBufferObejct.cpp
     ${FUNGT_BASE_DIR}/Shaders/shader.cpp
     ${FUNGT_BASE_DIR}/Shaders/opengl/opengl_shader.cpp
     ${FUNGT_BASE_DIR}/funGT/fungt.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/VertexGL/vertexArrayObjects.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexBuffers.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexIndices.cpp
+    ${FUNGT_BASE_DIR}/VertexGL/uniform_buffer_object.cpp
     ${FUNGT_BASE_DIR}/Shaders/shader.cpp
     ${FUNGT_BASE_DIR}/Shaders/opengl/opengl_shader.cpp
     ${FUNGT_BASE_DIR}/funGT/fungt.cpp

--- a/CubeMap/cube_map.hpp
+++ b/CubeMap/cube_map.hpp
@@ -57,8 +57,11 @@ class CubeMap : public Renderable {
         glm::mat4 getProjectionMatrix() override;
         Shader &getShader() override;
         void setViewMatrix(const glm::mat4 &viewMatrix) override;
-        void enableDepthFunc() override; 
-        void disableDepthFunc() override;   
+        void enableDepthFunc() override;
+        void disableDepthFunc() override;
+        RenderLayer getRenderLayer() const override {
+            return RenderLayer::Background;
+        }
 
         
 

--- a/GraphicsRenderBackend/gpu_buffer.hpp
+++ b/GraphicsRenderBackend/gpu_buffer.hpp
@@ -28,6 +28,9 @@ public:
     virtual void unbind() = 0;
     virtual void destroy() = 0;
 
+    virtual void update(const void* data, size_t size, size_t offset = 0) {}
+    virtual void bindBase(unsigned int bindingPoint) {}
+
     // VAO — OpenGL only, Vulkan impl leaves these empty
     virtual void genVAO()   {}
     virtual void bindVAO()  {}

--- a/GraphicsRenderBackend/opengl/opengl_buffer.cpp
+++ b/GraphicsRenderBackend/opengl/opengl_buffer.cpp
@@ -42,7 +42,9 @@ void OpenGLBuffer::create(BufferType type, const void* data, size_t size) {
             m_ebo.indexData(static_cast<const unsigned int*>(data), static_cast<unsigned int>(size));
             break;
         case BufferType::Uniform:
-            // Uniform buffers (UBOs) — to be implemented
+            m_ubo.create(size);
+            if (data)
+                m_ubo.setBufferData(data, size);
             break;
     }
 }
@@ -51,7 +53,7 @@ void OpenGLBuffer::bind() {
     switch (m_type) {
         case BufferType::Vertex:  m_vbo.bind(); break;
         case BufferType::Index:   m_ebo.bind(); break;
-        case BufferType::Uniform: break;
+        case BufferType::Uniform: m_ubo.bind(); break;
     }
 }
 
@@ -59,12 +61,19 @@ void OpenGLBuffer::unbind() {
     switch (m_type) {
         case BufferType::Vertex:  m_vbo.unbind(); break;
         case BufferType::Index:   m_ebo.unbind(); break;
-        case BufferType::Uniform: break;
+        case BufferType::Uniform: m_ubo.unbind(); break;
     }
 }
 
 void OpenGLBuffer::destroy() {
-    // VertexBuffer and VertexIndex destructors handle glDeleteBuffers
+}
+
+void OpenGLBuffer::update(const void* data, size_t size, size_t offset) {
+    m_ubo.setBufferData(data, size, offset);
+}
+
+void OpenGLBuffer::bindBase(unsigned int bindingPoint) {
+    m_ubo.bindBase(static_cast<GLuint>(bindingPoint));
 }
 
 void OpenGLBuffer::genVAO()    { m_vao.genVAO(); }

--- a/GraphicsRenderBackend/opengl/opengl_buffer.hpp
+++ b/GraphicsRenderBackend/opengl/opengl_buffer.hpp
@@ -5,6 +5,7 @@
 #include "../../VertexGL/vertexArrayObjects.hpp"
 #include "../../VertexGL/vertexBuffers.hpp"
 #include "../../VertexGL/vertexIndices.hpp"
+#include "../../VertexGL/uniform_buffer_object.hpp"
 
 class OpenGLBuffer : public GPUBuffer {
 public:
@@ -26,11 +27,15 @@ public:
     void drawIndexedInstanced(size_t indexCount, int instanceCount, DrawMode mode = DrawMode::Triangles) override;
     void drawArraysInstanced(size_t vertexCount, int instanceCount, DrawMode mode = DrawMode::Triangles) override;
 
+    void update(const void* data, size_t size, size_t offset = 0) override;
+    void bindBase(unsigned int bindingPoint) override;
+
 private:
-    BufferType        m_type;
-    VertexArrayObject m_vao;
-    VertexBuffer      m_vbo;
-    VertexIndex       m_ebo;
+    BufferType         m_type;
+    VertexArrayObject  m_vao;
+    VertexBuffer       m_vbo;
+    VertexIndex        m_ebo;
+    UniformBufferObject m_ubo;
 };
 
 #endif // _OPENGL_BUFFER_HPP_

--- a/PBR/main/CMakeLists.txt
+++ b/PBR/main/CMakeLists.txt
@@ -170,6 +170,7 @@ set(PBR_CORE_FILES
     ${FUNGT_BASE_DIR}/VertexGL/vertexBuffers.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexIndices.cpp
     ${FUNGT_BASE_DIR}/VertexGL/uniform_buffer_object.cpp
+    ${FUNGT_BASE_DIR}/VertexGL/shaderStorageBufferObejct.cpp
     ${FUNGT_BASE_DIR}/Matrix/matrix4x4f.cpp
     ${FUNGT_BASE_DIR}/Matrix/matrix3x3f.cpp
     ${FUNGT_BASE_DIR}/Renders/display_graphics.cpp

--- a/PBR/main/CMakeLists.txt
+++ b/PBR/main/CMakeLists.txt
@@ -169,6 +169,7 @@ set(PBR_CORE_FILES
     ${FUNGT_BASE_DIR}/VertexGL/vertexArrayObjects.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexBuffers.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexIndices.cpp
+    ${FUNGT_BASE_DIR}/VertexGL/uniform_buffer_object.cpp
     ${FUNGT_BASE_DIR}/Matrix/matrix4x4f.cpp
     ${FUNGT_BASE_DIR}/Matrix/matrix3x3f.cpp
     ${FUNGT_BASE_DIR}/Renders/display_graphics.cpp

--- a/Renderable/renderable.hpp
+++ b/Renderable/renderable.hpp
@@ -5,13 +5,18 @@
 #include "Shaders/shader.hpp"
 #include "Physics/RigidBody/rigid_body.hpp"
 
+enum class RenderLayer { Opaque, Background, Transparent };
+
 class Renderable{ //Abstract class
 
-    public: 
+    public:
 
 
         //Pure virtual functions
         virtual void draw() = 0;
+        virtual RenderLayer getRenderLayer() const {
+            return RenderLayer::Opaque;
+        }
         virtual Shader& getShader() = 0;
         virtual glm::mat4 getModelMatrix() const {
             return glm::mat4(0.0);

--- a/Samples/GUI/physics_controllers/CMakeLists.txt
+++ b/Samples/GUI/physics_controllers/CMakeLists.txt
@@ -233,6 +233,8 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/VertexGL/vertexArrayObjects.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexBuffers.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexIndices.cpp
+    ${FUNGT_BASE_DIR}/VertexGL/uniform_buffer_object.cpp
+    ${FUNGT_BASE_DIR}/VertexGL/shaderStorageBufferObejct.cpp
     ${FUNGT_BASE_DIR}/Shaders/shader.cpp
     ${FUNGT_BASE_DIR}/Shaders/opengl/opengl_shader.cpp
     ${FUNGT_BASE_DIR}/funGT/fungt.cpp

--- a/Samples/hdr_test/CMakeLists.txt
+++ b/Samples/hdr_test/CMakeLists.txt
@@ -233,6 +233,8 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/VertexGL/vertexArrayObjects.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexBuffers.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexIndices.cpp
+    ${FUNGT_BASE_DIR}/VertexGL/uniform_buffer_object.cpp
+    ${FUNGT_BASE_DIR}/VertexGL/shaderStorageBufferObejct.cpp
     ${FUNGT_BASE_DIR}/Shaders/shader.cpp
     ${FUNGT_BASE_DIR}/Shaders/opengl/opengl_shader.cpp
     ${FUNGT_BASE_DIR}/funGT/fungt.cpp

--- a/Samples/hdr_test/main.cpp
+++ b/Samples/hdr_test/main.cpp
@@ -13,13 +13,13 @@ int main() {
 
     FunGTSceneManager scene_manager = myGame->getSceneManager();
 
-    FunGTCubeMap skybox = CubeMap::create();
-     skybox->setShaders(getAssetPath("resources/equirect_skybox.vs"),
-                         getAssetPath("resources/equirect_skybox.fs"));
-     skybox->buildHDR(getAssetPath("assets_local/hdri/san_giuseppe_bridge_4k.hdr"));
+    // FunGTCubeMap skybox = CubeMap::create();
+    //  skybox->setShaders(getAssetPath("resources/equirect_skybox.vs"),
+    //                      getAssetPath("resources/equirect_skybox.fs"));
+    //  skybox->buildHDR(getAssetPath("assets_local/hdri/san_giuseppe_bridge_4k.hdr"));
 
-     scene_manager->loadEnvironment(getAssetPath("assets_local/hdri/san_giuseppe_bridge_4k.hdr"));
-     scene_manager->setIBLIntensity(1.3f);
+    //  scene_manager->loadEnvironment(getAssetPath("assets_local/hdri/san_giuseppe_bridge_4k.hdr"));
+    //  scene_manager->setIBLIntensity(1.3f);
 
     ModelPaths nightStreet;
     nightStreet.path = getAssetPath("assets_local/Obj/street/source/Wagon/#Ulica.obj");
@@ -31,7 +31,8 @@ int main() {
     street->scale(1.0);
 
     myGame->set([&]() {
-         scene_manager->addRenderableObj(skybox);
+         
+        //scene_manager->addRenderableObj(skybox);
         scene_manager->addRenderableObj(street);
         });
 

--- a/Samples/hdr_test/main.cpp
+++ b/Samples/hdr_test/main.cpp
@@ -13,13 +13,13 @@ int main() {
 
     FunGTSceneManager scene_manager = myGame->getSceneManager();
 
-    // FunGTCubeMap skybox = CubeMap::create();
-    // skybox->setShaders(getAssetPath("resources/equirect_skybox.vs"),
-    //                     getAssetPath("resources/equirect_skybox.fs"));
-    // skybox->buildHDR(getAssetPath("assets_local/hdri/san_giuseppe_bridge_4k.hdr"));
+    FunGTCubeMap skybox = CubeMap::create();
+     skybox->setShaders(getAssetPath("resources/equirect_skybox.vs"),
+                         getAssetPath("resources/equirect_skybox.fs"));
+     skybox->buildHDR(getAssetPath("assets_local/hdri/san_giuseppe_bridge_4k.hdr"));
 
-    // scene_manager->loadEnvironment(getAssetPath("assets_local/hdri/san_giuseppe_bridge_4k.hdr"));
-    // scene_manager->setIBLIntensity(1.3f);
+     scene_manager->loadEnvironment(getAssetPath("assets_local/hdri/san_giuseppe_bridge_4k.hdr"));
+     scene_manager->setIBLIntensity(1.3f);
 
     ModelPaths nightStreet;
     nightStreet.path = getAssetPath("assets_local/Obj/street/source/Wagon/#Ulica.obj");
@@ -31,7 +31,7 @@ int main() {
     street->scale(1.0);
 
     myGame->set([&]() {
-        // scene_manager->addRenderableObj(skybox);
+         scene_manager->addRenderableObj(skybox);
         scene_manager->addRenderableObj(street);
         });
 

--- a/Samples/iwocl/CMakeLists.txt
+++ b/Samples/iwocl/CMakeLists.txt
@@ -233,6 +233,7 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/VertexGL/vertexArrayObjects.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexBuffers.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexIndices.cpp
+    ${FUNGT_BASE_DIR}/VertexGL/uniform_buffer_object.cpp
     ${FUNGT_BASE_DIR}/Shaders/shader.cpp
     ${FUNGT_BASE_DIR}/Shaders/opengl/opengl_shader.cpp
     ${FUNGT_BASE_DIR}/funGT/fungt.cpp

--- a/SceneManager/scene_manager.cpp
+++ b/SceneManager/scene_manager.cpp
@@ -82,27 +82,50 @@ void SceneManager::renderScene()
     updateMatricesUBO();
     updateLightsUBO();
 
-    for(auto & node : m_VectorOfRenderNodes){
-        node->getShader().Bind();
-        node->enableDepthFunc(); //For Cubemap purposes
-        node->setViewMatrix(m_ViewMatrix);
-        node->updateModelMatrix();
-        node->updateTime(m_deltaTime);
-        node->getShader().setUniformVec3f(m_viewPos, "viewPos");
+    for (auto& layerBuckets : m_buckets)
+        for (auto& bucket : layerBuckets)
+            bucket.nodes.clear();
 
-        node->getShader().setUniform1i("hasIBL", m_hasIBL ? 1 : 0);
-        node->getShader().setUniformVec3f(m_ambientColor, "ambientColor");
-
-        if (m_hasIBL) {
-            glActiveTexture(GL_TEXTURE1);
-            glBindTexture(GL_TEXTURE_CUBE_MAP, m_iblProbe->getIrradianceMapID());
-            node->getShader().set1i(1, "irradianceMap");
-            node->getShader().setUniform1f(m_iblIntensity, "iblIntensity");
+    for (auto& node : m_VectorOfRenderNodes) {
+        auto& layerBuckets = m_buckets[static_cast<int>(node->getRenderLayer())];
+        Shader* shader = &node->getShader();
+        auto it = std::find_if(layerBuckets.begin(), layerBuckets.end(),
+            [shader](const ShaderBucket& b) { return b.shader == shader; });
+        if (it == layerBuckets.end()) {
+            layerBuckets.push_back(ShaderBucket{ shader, {} });
+            layerBuckets.back().nodes.reserve(m_VectorOfRenderNodes.size());
+            it = layerBuckets.end() - 1;
         }
+        it->nodes.push_back(node.get());
+    }
 
-        node->getShader().setUniformMat4fv("ModelMatrix",node->getModelMatrix());
-        node->draw();
-        node->disableDepthFunc(); //For CubeMap purposes
+    for (auto& layerBuckets : m_buckets) {
+        for (auto& bucket : layerBuckets) {
+            if (bucket.nodes.empty())
+                continue;
+            bucket.shader->Bind();
+            for (auto* node : bucket.nodes) {
+                node->enableDepthFunc(); //For Cubemap purposes
+                node->setViewMatrix(m_ViewMatrix);
+                node->updateModelMatrix();
+                node->updateTime(m_deltaTime);
+                node->getShader().setUniformVec3f(m_viewPos, "viewPos");
+
+                node->getShader().setUniform1i("hasIBL", m_hasIBL ? 1 : 0);
+                node->getShader().setUniformVec3f(m_ambientColor, "ambientColor");
+
+                if (m_hasIBL) {
+                    glActiveTexture(GL_TEXTURE1);
+                    glBindTexture(GL_TEXTURE_CUBE_MAP, m_iblProbe->getIrradianceMapID());
+                    node->getShader().set1i(1, "irradianceMap");
+                    node->getShader().setUniform1f(m_iblIntensity, "iblIntensity");
+                }
+
+                node->getShader().setUniformMat4fv("ModelMatrix",node->getModelMatrix());
+                node->draw();
+                node->disableDepthFunc(); //For CubeMap purposes
+            }
+        }
     }
 }
 void SceneManager::loadEnvironment(const std::string& hdrPath)

--- a/SceneManager/scene_manager.cpp
+++ b/SceneManager/scene_manager.cpp
@@ -1,9 +1,54 @@
 #include "scene_manager.hpp"
+#include <algorithm>
 
 SceneManager::SceneManager()
     : m_shader(Shader::create())
 {
     std::cout<<"Scene Manager Constructor"<<std::endl;
+}
+
+void SceneManager::initUBOs()
+{
+    m_matricesUBO = GPUBuffer::create();
+    m_matricesUBO->create(BufferType::Uniform, nullptr, sizeof(glm::mat4) * 2);
+    m_matricesUBO->bindBase(0);
+
+    const size_t lightStride = 32;
+    const size_t lightsUBOSize = lightStride * MAX_LIGHTS + 16;
+    m_lightsUBO = GPUBuffer::create();
+    m_lightsUBO->create(BufferType::Uniform, nullptr, lightsUBOSize);
+    m_lightsUBO->bindBase(1);
+}
+
+void SceneManager::updateMatricesUBO()
+{
+    if (!m_matricesUBO)
+        initUBOs();
+
+    glm::mat4 matrices[2] = { m_ViewMatrix, m_ProjectionMatrix };
+    m_matricesUBO->update(matrices, sizeof(matrices));
+}
+
+void SceneManager::updateLightsUBO()
+{
+    struct GPULight {
+        glm::vec3 position; float pad0;
+        glm::vec3 color;    float power;
+    };
+
+    const int count = static_cast<int>(std::min(m_lights.size(), static_cast<size_t>(MAX_LIGHTS)));
+    std::vector<GPULight> gpuLights(count);
+    for (int i = 0; i < count; ++i) {
+        gpuLights[i].position = m_lights[i].position;
+        gpuLights[i].color = m_lights[i].color;
+        gpuLights[i].power = m_lights[i].power;
+    }
+
+    if (count > 0)
+        m_lightsUBO->update(gpuLights.data(), gpuLights.size() * sizeof(GPULight));
+
+    const size_t lightStride = 32;
+    m_lightsUBO->update(&count, sizeof(int), lightStride * MAX_LIGHTS);
 }
 SceneManager:: ~SceneManager(){
     std::cout<<"Scene Manager Destructor"<<std::endl;
@@ -34,13 +79,15 @@ void SceneManager::updateModelMatrix(const glm::mat4 &modelMatrix)
 }
 void SceneManager::renderScene()
 {
+    updateMatricesUBO();
+    updateLightsUBO();
+
     for(auto & node : m_VectorOfRenderNodes){
         node->getShader().Bind();
         node->enableDepthFunc(); //For Cubemap purposes
         node->setViewMatrix(m_ViewMatrix);
         node->updateModelMatrix();
         node->updateTime(m_deltaTime);
-        node->getShader().setUniform1i("numLights", (int)m_lights.size());
         node->getShader().setUniformVec3f(m_viewPos, "viewPos");
 
         node->getShader().setUniform1i("hasIBL", m_hasIBL ? 1 : 0);
@@ -53,16 +100,6 @@ void SceneManager::renderScene()
             node->getShader().setUniform1f(m_iblIntensity, "iblIntensity");
         }
 
-        for (size_t i = 0; i < m_lights.size(); ++i)
-        {
-            const SceneLight& light = m_lights[i];
-            std::string idx = std::to_string(i);
-            node->getShader().setUniformVec3f(light.position, "light[" + idx + "].position");
-            node->getShader().setUniformVec3f(light.color, "light[" + idx + "].color");
-            node->getShader().setUniformVec1f(light.power, "light[" + idx + "].power");
-        }
-        node->getShader().setUniformMat4fv("ViewMatrix",node->getViewMatrix());
-        node->getShader().setUniformMat4fv("ProjectionMatrix",m_ProjectionMatrix);
         node->getShader().setUniformMat4fv("ModelMatrix",node->getModelMatrix());
         node->draw();
         node->disableDepthFunc(); //For CubeMap purposes

--- a/SceneManager/scene_manager.cpp
+++ b/SceneManager/scene_manager.cpp
@@ -50,6 +50,43 @@ void SceneManager::updateLightsUBO()
     const size_t lightStride = 32;
     m_lightsUBO->update(&count, sizeof(int), lightStride * MAX_LIGHTS);
 }
+void SceneManager::updateModelMatrixSSBO()
+{
+    if (!m_modelMatrixSSBOInitialized) {
+        m_modelMatrixSSBO.create(sizeof(glm::mat4) * m_VectorOfRenderNodes.size());
+        m_modelMatrixSSBO.bindToBase(2);
+        m_modelMatrixSSBOInitialized = true;
+    }
+
+    for (auto& layer_bucks : m_buckets)
+        for (auto& bucket : layer_bucks)
+            bucket.nodes.clear();
+
+    std::vector<glm::mat4> modelMatrices;
+    modelMatrices.reserve(m_VectorOfRenderNodes.size());
+    m_modelMatrixIndex.clear();
+
+    int index = 0;
+    for (auto& node : m_VectorOfRenderNodes) {
+        node->updateModelMatrix();
+        modelMatrices.push_back(node->getModelMatrix());
+        m_modelMatrixIndex[node.get()] = index;
+        ++index;
+
+        auto& layer_bucks = m_buckets[static_cast<int>(node->getRenderLayer())];
+        Shader* shader = &node->getShader();
+        auto it = std::find_if(layer_bucks.begin(), layer_bucks.end(),
+            [shader](const ShaderBucket& b) { return b.shader == shader; });
+        if (it == layer_bucks.end()) {
+            layer_bucks.push_back(ShaderBucket{ shader, {} });
+            layer_bucks.back().nodes.reserve(m_VectorOfRenderNodes.size());
+            it = layer_bucks.end() - 1;
+        }
+        it->nodes.push_back(node.get());
+    }
+
+    m_modelMatrixSSBO.setBuffData(modelMatrices.data(), modelMatrices.size() * sizeof(glm::mat4));
+}
 SceneManager:: ~SceneManager(){
     std::cout<<"Scene Manager Destructor"<<std::endl;
 }
@@ -81,33 +118,16 @@ void SceneManager::renderScene()
 {
     updateMatricesUBO();
     updateLightsUBO();
+    updateModelMatrixSSBO();
 
-    for (auto& layerBuckets : m_buckets)
-        for (auto& bucket : layerBuckets)
-            bucket.nodes.clear();
-
-    for (auto& node : m_VectorOfRenderNodes) {
-        auto& layerBuckets = m_buckets[static_cast<int>(node->getRenderLayer())];
-        Shader* shader = &node->getShader();
-        auto it = std::find_if(layerBuckets.begin(), layerBuckets.end(),
-            [shader](const ShaderBucket& b) { return b.shader == shader; });
-        if (it == layerBuckets.end()) {
-            layerBuckets.push_back(ShaderBucket{ shader, {} });
-            layerBuckets.back().nodes.reserve(m_VectorOfRenderNodes.size());
-            it = layerBuckets.end() - 1;
-        }
-        it->nodes.push_back(node.get());
-    }
-
-    for (auto& layerBuckets : m_buckets) {
-        for (auto& bucket : layerBuckets) {
+    for (auto& layer_bucks : m_buckets) {
+        for (auto& bucket : layer_bucks) {
             if (bucket.nodes.empty())
                 continue;
             bucket.shader->Bind();
             for (auto* node : bucket.nodes) {
                 node->enableDepthFunc(); //For Cubemap purposes
                 node->setViewMatrix(m_ViewMatrix);
-                node->updateModelMatrix();
                 node->updateTime(m_deltaTime);
                 node->getShader().setUniformVec3f(m_viewPos, "viewPos");
 
@@ -121,7 +141,7 @@ void SceneManager::renderScene()
                     node->getShader().setUniform1f(m_iblIntensity, "iblIntensity");
                 }
 
-                node->getShader().setUniformMat4fv("ModelMatrix",node->getModelMatrix());
+                node->getShader().setUniform1i("ModelMatrixIndex", m_modelMatrixIndex[node]);
                 node->draw();
                 node->disableDepthFunc(); //For CubeMap purposes
             }

--- a/SceneManager/scene_manager.hpp
+++ b/SceneManager/scene_manager.hpp
@@ -9,12 +9,19 @@
 #include "Lights/scene_light.hpp"
 #include "IBL/ibl_probe.hpp"
 #include "GraphicsRenderBackend/gpu_buffer.hpp"
+#include <array>
+
+struct ShaderBucket {
+    Shader* shader;
+    std::vector<Renderable*> nodes;
+};
 
 class SceneManager{
 
     private:
         std::unique_ptr<Shader> m_shader;
         std::vector<std::shared_ptr<Renderable>> m_VectorOfRenderNodes;
+        std::array<std::vector<ShaderBucket>, 3> m_buckets;
         glm::mat4 m_ViewMatrix = glm::mat4(1.f);
         glm::mat4 m_ProjectionMatrix = glm::mat4(1.f);
         glm::mat4 m_ModelMatrix = glm::mat4(1.f);

--- a/SceneManager/scene_manager.hpp
+++ b/SceneManager/scene_manager.hpp
@@ -8,6 +8,7 @@
 #include "SimpleModel/simple_model.hpp"
 #include "Lights/scene_light.hpp"
 #include "IBL/ibl_probe.hpp"
+#include "GraphicsRenderBackend/gpu_buffer.hpp"
 
 class SceneManager{
 
@@ -33,6 +34,13 @@ class SceneManager{
         float m_iblIntensity = 0.3f;
 
         glm::vec3 m_ambientColor = glm::vec3(0.3f, 0.3f, 0.3f);
+
+        static constexpr int MAX_LIGHTS = 32;
+        std::unique_ptr<GPUBuffer> m_matricesUBO;
+        std::unique_ptr<GPUBuffer> m_lightsUBO;
+        void initUBOs();
+        void updateMatricesUBO();
+        void updateLightsUBO();
     public:
         SceneManager();
         ~SceneManager();

--- a/SceneManager/scene_manager.hpp
+++ b/SceneManager/scene_manager.hpp
@@ -9,7 +9,9 @@
 #include "Lights/scene_light.hpp"
 #include "IBL/ibl_probe.hpp"
 #include "GraphicsRenderBackend/gpu_buffer.hpp"
+#include "VertexGL/shaderStorageBufferObejct.hpp"
 #include <array>
+#include <unordered_map>
 
 struct ShaderBucket {
     Shader* shader;
@@ -39,7 +41,10 @@ class SceneManager{
         std::unique_ptr<IBLProbe> m_iblProbe;
         bool m_hasIBL = false;
         float m_iblIntensity = 0.3f;
-
+        //Shader Storage Buffer Objects for matrices
+        SSBO m_modelMatrixSSBO;
+        bool m_modelMatrixSSBOInitialized = false;
+        std::unordered_map<Renderable*, int> m_modelMatrixIndex;
         glm::vec3 m_ambientColor = glm::vec3(0.3f, 0.3f, 0.3f);
 
         static constexpr int MAX_LIGHTS = 32;
@@ -48,6 +53,7 @@ class SceneManager{
         void initUBOs();
         void updateMatricesUBO();
         void updateLightsUBO();
+        void updateModelMatrixSSBO();
     public:
         SceneManager();
         ~SceneManager();

--- a/VertexGL/shaderStorageBufferObejct.cpp
+++ b/VertexGL/shaderStorageBufferObejct.cpp
@@ -1,0 +1,41 @@
+#include "shaderStorageBufferObejct.hpp"
+
+SSBO::SSBO()
+{
+    m_bufferId = 0;
+    m_bindingPoint = 0;
+    m_capacity = 0;
+}
+
+SSBO::~SSBO()
+{
+    if (m_bufferId) {
+        glDeleteBuffers(1, &m_bufferId);
+    }
+}
+
+void SSBO::bindToBase(unsigned int bindingPoint)
+{
+    m_bindingPoint = bindingPoint;
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, bindingPoint, m_bufferId);
+}
+
+void SSBO::create(unsigned int size)
+{
+    m_capacity = size;
+    glGenBuffers(1, &m_bufferId);
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, m_bufferId);
+    glBufferData(GL_SHADER_STORAGE_BUFFER, size, nullptr, GL_DYNAMIC_DRAW);
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+}
+
+void SSBO::setBuffData(const void* data, unsigned int size, unsigned int offset)
+{
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, m_bufferId);
+    if (size + offset > m_capacity) {
+        m_capacity = size + offset;
+        glBufferData(GL_SHADER_STORAGE_BUFFER, m_capacity, data, GL_DYNAMIC_DRAW);
+    } else {
+        glBufferSubData(GL_SHADER_STORAGE_BUFFER, offset, size, data);
+    }
+}

--- a/VertexGL/shaderStorageBufferObejct.hpp
+++ b/VertexGL/shaderStorageBufferObejct.hpp
@@ -1,0 +1,25 @@
+#if !defined(_SSBO_H_)
+#define _SSBO_H_
+#ifdef __APPLE__
+#define GLFW_INCLUDE_GLCOREARB
+#include <OpenGL/gl3.h>
+#include <OpenGL/gl3ext.h>
+#else
+#include <GL/glew.h>
+#endif
+
+class SSBO{
+
+    unsigned int m_bufferId;
+    unsigned int m_bindingPoint;
+    unsigned int m_capacity;
+public:
+    SSBO();
+    ~SSBO();
+    void bindToBase(unsigned int bindingPoint);
+    void create(unsigned int size);
+    void setBuffData(const void* data, unsigned int size, unsigned int offset = 0);
+    GLuint getId() const { return m_bufferId; }
+};
+
+#endif // _SSBO_H_

--- a/VertexGL/uniform_buffer_object.cpp
+++ b/VertexGL/uniform_buffer_object.cpp
@@ -1,0 +1,52 @@
+#include "uniform_buffer_object.hpp"
+
+UniformBufferObject::UniformBufferObject()
+{
+    m_bufferId = 0;
+    m_size = 0;
+    m_isBound = false;
+}
+
+UniformBufferObject::~UniformBufferObject()
+{
+    if (m_bufferId) {
+        glDeleteBuffers(1, &m_bufferId);
+    }
+}
+
+void UniformBufferObject::create(std::size_t size)
+{
+    m_size = size;
+    glGenBuffers(1, &m_bufferId);
+    glBindBuffer(GL_UNIFORM_BUFFER, m_bufferId);
+    glBufferData(GL_UNIFORM_BUFFER, size, nullptr, GL_DYNAMIC_DRAW);
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
+}
+
+void UniformBufferObject::bind()
+{
+    glBindBuffer(GL_UNIFORM_BUFFER, m_bufferId);
+    m_isBound = true;
+}
+
+void UniformBufferObject::unbind()
+{
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
+    m_isBound = false;
+}
+
+void UniformBufferObject::bindBase(GLuint bindingPoint)
+{
+    glBindBufferBase(GL_UNIFORM_BUFFER, bindingPoint, m_bufferId);
+}
+
+void UniformBufferObject::setBufferData(const void* data, std::size_t size, std::size_t offset)
+{
+    glBindBuffer(GL_UNIFORM_BUFFER, m_bufferId);
+    glBufferSubData(GL_UNIFORM_BUFFER, offset, size, data);
+}
+
+GLuint UniformBufferObject::getId() const
+{
+    return m_bufferId;
+}

--- a/VertexGL/uniform_buffer_object.hpp
+++ b/VertexGL/uniform_buffer_object.hpp
@@ -1,0 +1,31 @@
+#if !defined(_UNIFORM_BUFFER_OBJECT_H_)
+#define _UNIFORM_BUFFER_OBJECT_H_
+#ifdef __APPLE__
+#define GLFW_INCLUDE_GLCOREARB
+#include <OpenGL/gl3.h>
+#include <OpenGL/gl3ext.h>
+#else
+#include <GL/glew.h>
+#endif
+#include <cstddef>
+
+class UniformBufferObject {
+
+    GLuint m_bufferId;
+    std::size_t m_size;
+    bool m_isBound;
+
+    public:
+        UniformBufferObject();
+        ~UniformBufferObject();
+
+        void create(std::size_t size);
+        void bind();
+        void unbind();
+        void bindBase(GLuint bindingPoint);
+        void setBufferData(const void* data, std::size_t size, std::size_t offset = 0);
+        GLuint getId() const;
+
+};
+
+#endif // _UNIFORM_BUFFER_OBJECT_H_

--- a/resources/equirect_skybox.vs
+++ b/resources/equirect_skybox.vs
@@ -3,12 +3,15 @@ layout (location = 0) in vec3 aPos;
 
 out vec3 localPos;
 
-uniform mat4 ViewMatrix;
-uniform mat4 ProjectionMatrix;
+layout(std140, binding = 0) uniform Matrices {
+    mat4 ViewMatrix;
+    mat4 ProjectionMatrix;
+};
 
 void main()
 {
     localPos = aPos;
-    vec4 pos = ProjectionMatrix * ViewMatrix * vec4(aPos, 1.0f);
+    mat4 viewNoTranslation = mat4(mat3(ViewMatrix));
+    vec4 pos = ProjectionMatrix * viewNoTranslation * vec4(aPos, 1.0f);
     gl_Position = vec4(pos.x, pos.y, pos.w, pos.w);
 }

--- a/shaders/fungt_default.fs
+++ b/shaders/fungt_default.fs
@@ -13,7 +13,10 @@ struct Light {
     vec3  color;
     float power;
 };
-
+layout(std140, binding = 1) uniform LightsBlock {
+    Light light[32];
+    int   numLights;
+};
 in vec3 FragPos;
 in vec3 Normal;
 in vec2 textureCoords;
@@ -22,8 +25,6 @@ out vec4 vs_color;
 
 uniform vec3     viewPos;
 uniform Material material;
-uniform Light    light[8];
-uniform int      numLights;
 uniform sampler2D texture_diffuse1;
 uniform bool     hasTexture;
 uniform samplerCube irradianceMap;

--- a/shaders/fungt_default.vs
+++ b/shaders/fungt_default.vs
@@ -9,8 +9,10 @@ out vec3 Normal;
 out vec2 textureCoords;
 
 uniform mat4 ModelMatrix;
-uniform mat4 ViewMatrix;
-uniform mat4 ProjectionMatrix;
+layout(std140, binding = 0) uniform Matrices {
+    mat4 ViewMatrix;
+    mat4 ProjectionMatrix;
+};
 
 void main() {
     FragPos = vec3(ModelMatrix * vec4(vertex_position, 1.0));

--- a/shaders/fungt_default.vs
+++ b/shaders/fungt_default.vs
@@ -8,13 +8,17 @@ out vec3 FragPos;
 out vec3 Normal;
 out vec2 textureCoords;
 
-uniform mat4 ModelMatrix;
+uniform int ModelMatrixIndex;
 layout(std140, binding = 0) uniform Matrices {
     mat4 ViewMatrix;
     mat4 ProjectionMatrix;
 };
+layout(std430, binding = 2) readonly buffer ModelMatrices {
+    mat4 models[];
+};
 
 void main() {
+    mat4 ModelMatrix = models[ModelMatrixIndex];
     FragPos = vec3(ModelMatrix * vec4(vertex_position, 1.0));
     Normal = mat3(transpose(inverse(ModelMatrix))) * normal_position;
     textureCoords = texture_position;


### PR DESCRIPTION


## Description
<!-- Brief summary of what this PR does -->

FunGT was binding shaders at every iteration of the Renderable Objects loop, even if they shared same shaders. This optimization groups the renderable objects by shader. Now shader binding only happens once per group.
It also moves View and Projection matrices, array of lights, and Model matrices (for each object) out of individual renderable object uniform uploads. Now those loads use SSBOs and UBOs

## Type of Change
<!-- Mark with [x] -->
- [x]   Performance (improves performance)
