### PR TITLE
Make matching material representation between rasterizer and rayspace

### DIFF
--- a/GUI/material_editor_window.hpp
+++ b/GUI/material_editor_window.hpp
@@ -131,29 +131,21 @@ public:
         ImGui::Separator();
         ImGui::Spacing();
 
-        // Ambient color
-        ImGui::Text("Ambient");
-        ImGui::ColorEdit3("##Ambient", &mat.m_ambientLight.x, ImGuiColorEditFlags_Float);
-
-        ImGui::Spacing();
-
-        // Diffuse color
-        ImGui::Text("Diffuse");
-        ImGui::ColorEdit3("##Diffuse", &mat.m_diffLigth.x, ImGuiColorEditFlags_Float);
-
-        ImGui::Spacing();
-
-        // Specular color
-        ImGui::Text("Specular");
-        ImGui::ColorEdit3("##Specular", &mat.m_specLight.x, ImGuiColorEditFlags_Float);
+        ImGui::Text("Base Color");
+        ImGui::ColorEdit3("##BaseColor", &mat.m_baseColor.x, ImGuiColorEditFlags_Float);
 
         ImGui::Spacing();
         ImGui::Separator();
         ImGui::Spacing();
 
-        // Shininess slider
-        ImGui::Text("Shininess");
-        ImGui::SliderFloat("##Shininess", &mat.m_shininess, 1.0f, 128.0f, "%.1f");
+        ImGui::Text("Metallic");
+        ImGui::SliderFloat("##Metallic", &mat.m_metallic, 0.0f, 1.0f, "%.3f");
+
+        ImGui::Text("Roughness");
+        ImGui::SliderFloat("##Roughness", &mat.m_roughness, 0.05f, 1.0f, "%.3f");
+
+        ImGui::Text("Reflectance");
+        ImGui::SliderFloat("##Reflectance", &mat.m_reflectance, 0.0f, 1.0f, "%.3f");
 
         ImGui::Spacing();
         ImGui::Separator();

--- a/GraphicsRenderBackend/gpu_texture.hpp
+++ b/GraphicsRenderBackend/gpu_texture.hpp
@@ -11,16 +11,17 @@ enum class TextureType {
     Texture2D,
     CubeMap
 };
-
+enum class TextureColorSpace {
+    Linear,
+    SRGB
+};
 class GPUTexture {
 public:
     virtual ~GPUTexture() = default;
 
-    virtual void upload(const unsigned char* pixels, int width, int height) = 0;
+    virtual void upload(const unsigned char* pixels, int width, int height, TextureColorSpace colorSpace) = 0;
     virtual void uploadFloat(const float* pixels, int width, int height) = 0;
     virtual void uploadCubeMap(const std::vector<unsigned char*>& faces, int width, int height) = 0;
-    // Allocates an empty, mutable float cubemap with no face data, for use as a render
-    // target (e.g. equirect->cubemap conversion, irradiance/prefilter convolution passes).
     virtual void allocateEmptyCubemap(int faceSize, bool mipmaps) = 0;
     virtual void bind(unsigned int slot = 0) = 0;
     virtual void unbind() = 0;

--- a/GraphicsRenderBackend/opengl/opengl_texture.cpp
+++ b/GraphicsRenderBackend/opengl/opengl_texture.cpp
@@ -15,7 +15,7 @@ OpenGLTexture::~OpenGLTexture() {
     destroy();
 }
 
-void OpenGLTexture::upload(const unsigned char* pixels, int width, int height) {
+void OpenGLTexture::upload(const unsigned char* pixels, int width, int height, TextureColorSpace colorSpace){
     glGenTextures(1, &m_id);
     glBindTexture(m_glTarget, m_id);
 
@@ -24,7 +24,13 @@ void OpenGLTexture::upload(const unsigned char* pixels, int width, int height) {
     glTexParameteri(m_glTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(m_glTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
 
-    glTexImage2D(m_glTarget, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    const GLenum internalFormat =
+        colorSpace == TextureColorSpace::SRGB
+        ? GL_SRGB8_ALPHA8
+        : GL_RGBA8;
+
+
+    glTexImage2D(m_glTarget, 0, internalFormat, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
     glGenerateMipmap(m_glTarget);
     glBindTexture(m_glTarget, 0);
 }

--- a/GraphicsRenderBackend/opengl/opengl_texture.hpp
+++ b/GraphicsRenderBackend/opengl/opengl_texture.hpp
@@ -9,7 +9,7 @@ public:
     OpenGLTexture(TextureType type = TextureType::Texture2D);
     ~OpenGLTexture() override;
 
-    void upload(const unsigned char* pixels, int width, int height) override;
+    void upload(const unsigned char* pixels, int width, int height, TextureColorSpace colorSpace) override;
     void uploadFloat(const float* pixels, int width, int height) override;
     void uploadCubeMap(const std::vector<unsigned char*>& faces, int width, int height) override;
     void allocateEmptyCubemap(int faceSize, bool mipmaps) override;

--- a/Material/material.cpp
+++ b/Material/material.cpp
@@ -1,83 +1,38 @@
 #include "material.hpp"
-Material::Material(){
-    
-}
-Material::Material(glm::vec3 _ambientLight, glm::vec3 _diffLigth, glm::vec3 _specLight,float inShin,std::string name, float emission)
-: m_ambientLight{_ambientLight}, m_diffLigth{_diffLigth}, m_specLight{_specLight},m_shininess{inShin},m_name{name},m_emission{emission}{
-
-}
-Material::~Material(){
-
-}
-
-Material::Material(const Material& other)
-    : m_ambientLight(other.m_ambientLight)
-    , m_diffLigth(other.m_diffLigth)
-    , m_specLight(other.m_specLight)
-    , m_shininess(other.m_shininess)
-    , m_name(other.m_name)
-    , m_emission(other.m_emission)
+Material::Material(glm::vec3 baseColor, float metallic, float roughness,
+                   float reflectance, std::string name, float emission)
+    : m_baseColor(baseColor)
+    , m_metallic(glm::clamp(metallic, 0.0f, 1.0f))
+    , m_roughness(glm::clamp(roughness, 0.05f, 1.0f))
+    , m_reflectance(glm::clamp(reflectance, 0.0f, 1.0f))
+    , m_emission(emission)
+    , m_name(std::move(name))
 {
 }
 
-Material::Material(Material&& other) noexcept
-    : m_ambientLight(other.m_ambientLight)
-    , m_diffLigth(other.m_diffLigth)
-    , m_specLight(other.m_specLight)
-    , m_shininess(other.m_shininess)
-    , m_name(std::move(other.m_name))
-    , m_emission(other.m_emission)
-{
-}
-
-Material& Material::operator=(const Material& other) {
-    if (this == &other) return *this;
-    m_ambientLight = other.m_ambientLight;
-    m_diffLigth = other.m_diffLigth;
-    m_specLight = other.m_specLight;
-    m_shininess = other.m_shininess;
-    m_name      = other.m_name;
-    m_emission  = other.m_emission;
-    return *this;
-}
-
-Material& Material::operator=(Material&& other) noexcept {
-    if (this == &other) return *this;
-    m_ambientLight = other.m_ambientLight;
-    m_diffLigth = other.m_diffLigth;
-    m_specLight = other.m_specLight;
-    m_shininess = other.m_shininess;
-    m_name = std::move(other.m_name);
-    m_emission = other.m_emission;
-    return *this;
-}
-void Material::sendToShader(Shader& program) {
-
-    program.setUniformVec3f(m_ambientLight, "material.ambient");
-    program.setUniformVec3f(m_diffLigth, "material.diffuse");
-    program.setUniformVec3f(m_specLight, "material.specular");
-    program.setUniform1f(m_shininess, "material.shininess");
+void Material::sendToShader(Shader& program) const {
+    program.setUniformVec3f(m_baseColor, "material.baseColor");
+    program.setUniform1f(m_metallic, "material.metallic");
+    program.setUniform1f(m_roughness, "material.roughness");
+    program.setUniform1f(m_reflectance, "material.reflectance");
     program.setUniform1f(m_emission, "material.emission");
+
+    // Compatibility for custom shaders that still use the legacy Phong fields.
+    const glm::vec3 specular = glm::mix(glm::vec3(m_reflectance), m_baseColor, m_metallic);
+    const float shininess = glm::max(1.0f, 2.0f / (m_roughness * m_roughness) - 2.0f);
+    program.setUniformVec3f(m_baseColor, "material.ambient");
+    program.setUniformVec3f(m_baseColor, "material.diffuse");
+    program.setUniformVec3f(specular, "material.specular");
+    program.setUniform1f(shininess, "material.shininess");
 }
 
 bool Material::isInvalidMaterial() const
 {
-    // Check if ambient AND diffuse are essentially zero
-    // (specular alone won't make the mesh visible)
     const float epsilon = 0.001f;
-    return (glm::length(m_ambientLight) < epsilon &&
-        glm::length(m_diffLigth) < epsilon);
-    // Note: We don't check specular - it can be non-zero but won't help if base colors are black
+    return glm::length(m_baseColor) < epsilon;
 }
 
 Material Material::createDefaultMaterial()
 {
-    // Nice neutral gray;
-    glm::vec3 ambient(0.2f, 0.2f, 0.2f);
-    glm::vec3 diffuse(0.8f, 0.8f, 0.8f);
-    glm::vec3 specular(0.5f, 0.5f, 0.5f);
-    float shininess = 32.0f;
-    float emission  = 0.f;
-
-    return Material(ambient, diffuse, specular, shininess, "FunGT_Default", emission);
+    return Material(glm::vec3(0.8f), 0.0f, 0.5f, 0.04f, "FunGT_Default");
 }

--- a/Material/material.hpp
+++ b/Material/material.hpp
@@ -1,25 +1,21 @@
 #if !defined(_MATERIAL_FUNGT_H_)
 #define _MATERIAL_FUNGT_H_
-#include "../Shaders/shader.hpp"
+#include "Shaders/shader.hpp"
 class Material
 {   public:
-        glm::vec3 m_ambientLight; 
-        glm::vec3 m_diffLigth; 
-        glm::vec3 m_specLight;
-        float m_shininess;
+        glm::vec3 m_baseColor = glm::vec3(0.8f);
+        float m_metallic = 0.0f;
+        float m_roughness = 0.5f;
+        float m_reflectance = 0.04f;
         float m_emission = 0.0f;
 
     public:
         std::string m_name;
-        Material(); 
-        Material(glm::vec3 ambientLight, glm::vec3 diffLigth, glm::vec3 specLight,float inShin,std::string name, float emission = 0.0f);
-        Material(const Material& other);
-        Material(Material&& other) noexcept;
-        Material& operator=(const Material& other);
-        Material& operator=(Material&& other) noexcept;
-
-        ~Material();
-        void sendToShader(Shader& program);
+        Material() = default;
+        Material(glm::vec3 baseColor, float metallic, float roughness,
+                 float reflectance, std::string name, float emission = 0.0f);
+        ~Material() = default;
+        void sendToShader(Shader& program) const;
         bool isInvalidMaterial() const;
         static Material createDefaultMaterial();
 

--- a/Model/model.cpp
+++ b/Model/model.cpp
@@ -373,45 +373,28 @@ std::vector<Texture > Model::loadTextures(aiMaterial *mat, aiTextureType type, s
     return textures;
 }
 std::vector<Material> Model::loadMaterials(aiMaterial *mat)
-{   std::vector<Material> internalMat; 
-    glm::vec3 ka;
-    glm::vec3 kd; 
-    glm::vec3 ks;
-    float shininess;
-    
-
+{
     aiString aiName; 
-
-    //Gets the name of the material: 
     mat->Get(AI_MATKEY_NAME,aiName);
+    const std::string name = aiName.C_Str();
+    std::cout << "Loading : " << name << std::endl;
 
+    aiColor3D aiDiffuseColor(0.8f, 0.8f, 0.8f);
+    aiColor3D aiSpecularColor(0.04f, 0.04f, 0.04f);
+    float shininess = 2.0f;
 
-    const char * name = aiName.C_Str();
-
-    std::string nameMaterial(name);
-
-    std::cout<<"Loading : " << nameMaterial <<std::endl;
-    
-    aiColor3D aiAmbientColor, aiDiffuseColor, aiSpecularColor;
-    float aiShininess;
-    //Gets the values of the properties
-    mat->Get(AI_MATKEY_COLOR_AMBIENT, aiAmbientColor);
-    ka = glm::vec3(aiAmbientColor.r,aiAmbientColor.g,aiAmbientColor.b);
-    //std::cout<<"ka : " << ka.x << ", " << ka.y <<", " << ka.z <<std::endl;
     mat->Get(AI_MATKEY_COLOR_DIFFUSE, aiDiffuseColor);
-    kd = glm::vec3(aiDiffuseColor.r,aiDiffuseColor.g,aiDiffuseColor.b);
-
     mat->Get(AI_MATKEY_COLOR_SPECULAR, aiSpecularColor);
-    ks = glm::vec3(aiSpecularColor.r,aiSpecularColor.g,aiSpecularColor.b);
+    mat->Get(AI_MATKEY_SHININESS, shininess);
 
-    mat->Get(AI_MATKEY_SHININESS, aiShininess);
-    shininess = static_cast<float>(aiShininess);
+    const glm::vec3 baseColor(aiDiffuseColor.r, aiDiffuseColor.g, aiDiffuseColor.b);
+    const float roughness = glm::clamp(std::sqrt(2.0f / (shininess + 2.0f)), 0.05f, 1.0f);
+    const float reflectance = glm::clamp(
+        (aiSpecularColor.r + aiSpecularColor.g + aiSpecularColor.b) / 3.0f,
+        0.0f, 1.0f);
 
-    Material myMaterial(ka,ks,kd,shininess,name);
-
-    internalMat.push_back(myMaterial); 
-
-    return internalMat;
+    // Legacy Phong/MTL data has no reliable metallic parameter.
+    return { Material(baseColor, 0.0f, roughness, reflectance, name) };
 }
 void Model::initializeDefaultShaders()
 {

--- a/PBR/Intersection/intersection.hpp
+++ b/PBR/Intersection/intersection.hpp
@@ -77,7 +77,7 @@ class Intersection{
                 tMax = fminf(t1, tMax);
 
                 // Early exit if no overlap
-                if (tMax <= tMin)
+                if (tMax < tMin)
                     return false;
             }
             return true;

--- a/PBR/Render/shared/core_renderer.hpp
+++ b/PBR/Render/shared/core_renderer.hpp
@@ -73,9 +73,7 @@ fgt_device_gpu inline fungt::Vec3 sampleHemisphere(const fungt::Vec3& normal, fu
 
 }
 fgt_device fungt::Vec3 skyColor(const fungt::Ray& ray) {
-    float t = 0.5f * (ray.m_dir.y + 1.0f);
-    //return (1.0f - t) * fungt::Vec3(1.0f, 1.0f, 1.0f) + t * fungt::Vec3(0.5f, 0.7f, 1.0f)*3.0f;
-    return fungt::Vec3(0.0f, 0.0f, 0.0f); // Bright blu
+    return fungt::Vec3(0.3f, 0.3f, 0.3f);
     //return (t * fungt::Vec3(2.0f, 2.0f, 2.0f) + (1.0f - t) * fungt::Vec3(0.3f, 0.5f, 1.0f));
 
     // float t = 0.5f * (ray.m_dir.y + 1.0f);

--- a/PBR/Space/space.cpp
+++ b/PBR/Space/space.cpp
@@ -59,7 +59,6 @@ Space::Space(){
 
 Space::Space(std::vector<Triangle>& triangleList)
 {
-    Material gray(glm::vec3(0.2f), glm::vec3(0.8f), glm::vec3(0.8f), 32.0f, "DefaultGray");
     m_triangles = std::move(triangleList);
     m_lights.push_back(Light(
         fungt::Vec3(2.0f, 2.0f, 2.0f),    // position
@@ -237,7 +236,7 @@ void Space::LoadModelToRender(const SimpleModel& Simplemodel)
         global_material.metallic = 0.0f;
         global_material.roughness = 0.5f;
         global_material.reflectance = 0.05f;
-        global_material.emission = materials[0].m_emission;
+        global_material.emission = 0.0f;
         global_material.baseColorTexIdx = -1;
         if (!textures.empty() && m_textureManager != nullptr) {
             std::string texPath = textures[0].getPath();
@@ -249,17 +248,13 @@ void Space::LoadModelToRender(const SimpleModel& Simplemodel)
             std::cout << "  No texture (using base color)" << std::endl;
         }
         if (!materials.empty()) {
-            global_material.baseColor[0] = materials[0].m_diffLigth.x;
-            global_material.baseColor[1] = materials[0].m_diffLigth.y;
-            global_material.baseColor[2] = materials[0].m_diffLigth.z;
-
-            float Ns = materials[0].m_shininess;
-            global_material.roughness = sqrtf(2.0f / (Ns + 2.0f));
-
-            float avgSpec = (materials[0].m_specLight.x +
-                materials[0].m_specLight.y +
-                materials[0].m_specLight.z) / 3.0f;
-            global_material.metallic = (avgSpec < 0.9f) ? 0.0f : 0.3f;
+            global_material.baseColor[0] = materials[0].m_baseColor.x;
+            global_material.baseColor[1] = materials[0].m_baseColor.y;
+            global_material.baseColor[2] = materials[0].m_baseColor.z;
+            global_material.metallic = materials[0].m_metallic;
+            global_material.roughness = materials[0].m_roughness;
+            global_material.reflectance = materials[0].m_reflectance;
+            global_material.emission = materials[0].m_emission;
 
             std::cout << "Material: Base color ("
                 << global_material.baseColor[0] << ", "
@@ -479,6 +474,5 @@ void Space::setSamples(int numOfSamples)
 {
     m_samplesPerPixel = numOfSamples;
 }
-
 
 

--- a/SimpleGeometry/simple_geometry.cpp
+++ b/SimpleGeometry/simple_geometry.cpp
@@ -63,10 +63,10 @@ void SimpleGeometry::scale(float s) {
 
 void SimpleGeometry::draw() {
     if (m_primitive) {
-        m_Shader->setUniformVec3f(m_material.baseColor, "material.diffuse");
-        m_Shader->setUniformVec3f(m_material.baseColor * 0.3f, "material.ambient");
-        m_Shader->setUniformVec3f(glm::vec3(1.0f - m_material.roughness), "material.specular");
-        m_Shader->setUniformVec1f(glm::mix(2.f, 128.f, 1.f - m_material.roughness), "material.shininess");
+        m_Shader->setUniformVec3f(m_material.baseColor, "material.baseColor");
+        m_Shader->setUniformVec1f(m_material.metallic, "material.metallic");
+        m_Shader->setUniformVec1f(m_material.roughness, "material.roughness");
+        m_Shader->setUniformVec1f(0.04f, "material.reflectance");
         m_Shader->setUniformVec1f(0.f, "material.emission");
         m_Shader->setUniform1i("hasTexture", m_isTexturized ? 1 : 0);
         m_primitive->draw();

--- a/Textures/textures.cpp
+++ b/Textures/textures.cpp
@@ -24,7 +24,7 @@ Texture::~Texture() {
     std::cout << "Texture Destructor" << std::endl;
 }
 
-void Texture::genTexture(const std::string& path) {
+void Texture::genTexture(const std::string& path, TextureColorSpace colorSpace) {
     txt_Path = path;
     stbi_set_flip_vertically_on_load(1);
     unsigned char* pixels = stbi_load(txt_Path.c_str(), &txt_width, &txt_height, &txt_BBP, 4);
@@ -32,7 +32,7 @@ void Texture::genTexture(const std::string& path) {
     if (pixels) {
         std::cout << "\nOk to load: " << std::endl;
         printf("%s\n", txt_Path.c_str());
-        m_gpu->upload(pixels, txt_width, txt_height);
+        m_gpu->upload(pixels, txt_width, txt_height, colorSpace);
         stbi_image_free(pixels);
     } else {
         std::cout << "\nError: Failed to load texture" << std::endl;

--- a/Textures/textures.hpp
+++ b/Textures/textures.hpp
@@ -3,7 +3,7 @@
 #include <vector>
 #include <string>
 #include <memory>
-#include "../GraphicsRenderBackend/gpu_texture.hpp"
+#include "GraphicsRenderBackend/gpu_texture.hpp"
 
 class Texture {
 public:
@@ -27,7 +27,8 @@ public:
     Texture(const Texture&) = delete;
     Texture& operator=(const Texture&) = delete;
 
-    void genTexture(const std::string& path);
+    void genTexture(const std::string& path, 
+                    TextureColorSpace colorSpace = TextureColorSpace::SRGB);
     void genTextureHDR(const std::string& path);
     void genTextureCubeMap(const std::vector<std::string>& faces);
     void allocateEmptyCubemap(int faceSize, bool mipmaps);

--- a/shaders/fungt_default.fs
+++ b/shaders/fungt_default.fs
@@ -1,10 +1,10 @@
 #version 440
 
 struct Material {
-    vec3  ambient;
-    vec3  diffuse;
-    vec3  specular;
-    float shininess;
+    vec3  baseColor;
+    float metallic;
+    float roughness;
+    float reflectance;
     float emission;
 };
 
@@ -32,13 +32,42 @@ uniform bool     hasIBL;
 uniform float    iblIntensity;
 uniform vec3     ambientColor;
 
+const float PI = 3.14159265359;
+
+float distributionGGX(vec3 N, vec3 H, float roughness)
+{
+    float a = roughness * roughness;
+    float a2 = a * a;
+    float nDotH = max(dot(N, H), 0.0);
+    float d = nDotH * nDotH * (a2 - 1.0) + 1.0;
+    return a2 / max(PI * d * d, 1e-6);
+}
+
+float geometrySchlickGGX(float nDotX, float roughness)
+{
+    float r = roughness + 1.0;
+    float k = (r * r) / 8.0;
+    return nDotX / max(nDotX * (1.0 - k) + k, 1e-6);
+}
+
+float geometrySmith(vec3 N, vec3 V, vec3 L, float roughness)
+{
+    return geometrySchlickGGX(max(dot(N, V), 0.0), roughness) *
+           geometrySchlickGGX(max(dot(N, L), 0.0), roughness);
+}
+
+vec3 fresnelSchlick(float cosTheta, vec3 f0)
+{
+    return f0 + (1.0 - f0) * pow(1.0 - cosTheta, 5.0);
+}
+
 void main()
 {
     vec3 baseColor;
     if (hasTexture)
         baseColor = texture(texture_diffuse1, textureCoords).rgb;
     else
-        baseColor = material.diffuse;
+        baseColor = material.baseColor;
 
     vec3 norm    = normalize(Normal);
     vec3 viewDir = normalize(viewPos - FragPos);
@@ -53,21 +82,26 @@ void main()
         float attenuation = 1.0 / (dist * dist + 1e-6f);
         vec3  radiance   = light[i].color * light[i].power * attenuation;
 
-        // Diffuse
-        float diff = max(dot(norm, lightDir), 0.0);
-        totalDiffuse += radiance * diff * baseColor;
+        vec3 halfway = normalize(viewDir + lightDir);
+        float nDotL = max(dot(norm, lightDir), 0.0);
+        float nDotV = max(dot(norm, viewDir), 0.0);
+        vec3 f0 = mix(vec3(material.reflectance), baseColor, material.metallic);
+        vec3 fresnel = fresnelSchlick(max(dot(halfway, viewDir), 0.0), f0);
+        float distribution = distributionGGX(norm, halfway, material.roughness);
+        float geometry = geometrySmith(norm, viewDir, lightDir, material.roughness);
+        vec3 specular = distribution * geometry * fresnel /
+            max(4.0 * nDotV * nDotL, 1e-4);
+        vec3 diffuseWeight = (vec3(1.0) - fresnel) * (1.0 - material.metallic);
 
-        // Specular
-        vec3  reflectDir = reflect(-lightDir, norm);
-        float spec       = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
-        totalSpecular += radiance * spec * material.specular;
+        totalDiffuse += radiance * diffuseWeight * baseColor / PI * nDotL;
+        totalSpecular += radiance * specular * nDotL;
     }
 
     vec3 ambient;
     if (hasIBL)
-        ambient = texture(irradianceMap, norm).rgb * iblIntensity * baseColor * material.ambient;
+        ambient = texture(irradianceMap, norm).rgb * iblIntensity * baseColor * (1.0 - material.metallic);
     else
-        ambient = ambientColor * material.ambient * baseColor;
+        ambient = ambientColor * baseColor * (1.0 - material.metallic);
 
     vec3 emissive = baseColor * material.emission;
     vec3 result   = ambient + totalDiffuse + totalSpecular + emissive;


### PR DESCRIPTION
## Description

FunGT real time rasterization render was using legacy Phong material fields, while RaySpace uses  PBR properties. This PR unifies both renderers by 

- Convert imported Phong materials to metallic-roughness values
- Update raster shading to use Cook-Torrance
- Copy canonical materials directly into path-tracing data
- Add explicit linear and sRGB texture color spaces
## Type of Change
<!-- Mark with [x] -->
- [ ]  Bug fix (non-breaking change that fixes an issue)
- [x]  New feature (non-breaking change that adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)
- [ ]  Refactor (code change that neither fixes a bug nor adds a feature)
- [ ]  Documentation (changes to docs only)
- [ ]  Performance (improves performance)
