### PR TITLE
Split mesh into mesh meshgpu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,8 @@ include_directories(
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl
     ${FUNGT_BASE_DIR}/MeshGPU
+    ${FUNGT_BASE_DIR}/TextureGPU
+    ${FUNGT_BASE_DIR}/PrimitiveGPU
 )
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -246,6 +248,8 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/Material/material.cpp
     ${FUNGT_BASE_DIR}/Mesh/mesh.cpp
     ${FUNGT_BASE_DIR}/MeshGPU/mesh_gpu.cpp
+    ${FUNGT_BASE_DIR}/TextureGPU/texture_gpu.cpp
+    ${FUNGT_BASE_DIR}/PrimitiveGPU/primitive_gpu.cpp
     ${FUNGT_BASE_DIR}/Camera/camera.cpp
     ${FUNGT_BASE_DIR}/Geometries/cube.cpp
     ${FUNGT_BASE_DIR}/Geometries/plane.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ include_directories(
     ${FUNGT_BASE_DIR}/IBL
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl
+    ${FUNGT_BASE_DIR}/MeshGPU
 )
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -244,6 +245,7 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/Imgui_Setup/imgui_setup.cpp
     ${FUNGT_BASE_DIR}/Material/material.cpp
     ${FUNGT_BASE_DIR}/Mesh/mesh.cpp
+    ${FUNGT_BASE_DIR}/MeshGPU/mesh_gpu.cpp
     ${FUNGT_BASE_DIR}/Camera/camera.cpp
     ${FUNGT_BASE_DIR}/Geometries/cube.cpp
     ${FUNGT_BASE_DIR}/Geometries/plane.cpp

--- a/GT/graphicsTool.cpp
+++ b/GT/graphicsTool.cpp
@@ -1,5 +1,17 @@
 #include "graphicsTool.hpp"
 #include "../MeshGPU/mesh_gpu.hpp"
+#include "../TextureGPU/texture_gpu.hpp"
+#include "../PrimitiveGPU/primitive_gpu.hpp"
+#include "../Shaders/shader.hpp"
+#include "../Model/model.hpp"
+
+Shader* BuildShader() {
+    return Shader::create().release();
+}
+
+void FreeShader(Shader* s) {
+    delete s;
+}
 
 
 GraphicsTool::GraphicsTool(int _width, int _height)
@@ -47,6 +59,10 @@ int GraphicsTool::initGL(){
 
     m_renderDevice->init(m_Window, m_frameBufferWidth, m_frameBufferHeight, m_colors);
     RegisterMeshGPUCallbacks();
+    RegisterTextureGPUCallbacks();
+    RegisterPrimitiveGPUCallbacks();
+    Model::s_shaderCreate = &BuildShader;
+    Model::s_shaderFree = &FreeShader;
 
     return 1;
 }

--- a/GT/graphicsTool.cpp
+++ b/GT/graphicsTool.cpp
@@ -1,4 +1,5 @@
 #include "graphicsTool.hpp"
+#include "../MeshGPU/mesh_gpu.hpp"
 
 
 GraphicsTool::GraphicsTool(int _width, int _height)
@@ -45,6 +46,7 @@ int GraphicsTool::initGL(){
     });
 
     m_renderDevice->init(m_Window, m_frameBufferWidth, m_frameBufferHeight, m_colors);
+    RegisterMeshGPUCallbacks();
 
     return 1;
 }

--- a/Geometries/box.cpp
+++ b/Geometries/box.cpp
@@ -11,9 +11,9 @@ geometry::Box::~Box() {
 
 void geometry::Box::draw() {
     texture.active();
-    m_buffer->bindVAO();
-    m_buffer->drawArrays(getNumOfVertices());
-    m_buffer->unbindVAO();
+    if (s_gpuDraw && m_gpuCache) {
+        s_gpuDraw(*m_gpuCache, 0, getNumOfVertices());
+    }
 }
 
 void geometry::Box::setData() {
@@ -81,7 +81,7 @@ void geometry::Box::setData() {
 void geometry::Box::InstancedDraw(Shader& shader, int instanceCount) {
     shader.setUniformVec3f(glm::vec3(0.4f, 0.4f, 0.4f), "u_color");
     texture.active();
-    m_buffer->bindVAO();
-    m_buffer->drawArraysInstanced(getNumOfVertices(), instanceCount);
-    m_buffer->unbindVAO();
+    if (s_gpuDrawInstanced && m_gpuCache) {
+        s_gpuDrawInstanced(*m_gpuCache, 0, getNumOfVertices(), instanceCount);
+    }
 }

--- a/Geometries/cube.cpp
+++ b/Geometries/cube.cpp
@@ -11,9 +11,9 @@ Cube::~Cube() {
 
 void Cube::draw() {
     texture.active();
-    m_buffer->bindVAO();
-    m_buffer->drawArrays(getNumOfVertices());
-    m_buffer->unbindVAO();
+    if (s_gpuDraw && m_gpuCache) {
+        s_gpuDraw(*m_gpuCache, 0, getNumOfVertices());
+    }
 }
 
 void Cube::setData() {
@@ -73,7 +73,7 @@ void Cube::setData() {
 
 void Cube::InstancedDraw(Shader& shader, int instanceCount) {
     texture.active();
-    m_buffer->bindVAO();
-    m_buffer->drawArraysInstanced(getNumOfVertices(), instanceCount);
-    m_buffer->unbindVAO();
+    if (s_gpuDrawInstanced && m_gpuCache) {
+        s_gpuDrawInstanced(*m_gpuCache, 0, getNumOfVertices(), instanceCount);
+    }
 }

--- a/Geometries/plane.cpp
+++ b/Geometries/plane.cpp
@@ -11,9 +11,9 @@ Plane::~Plane() {
 
 void Plane::draw() {
     texture.active();
-    m_buffer->bindVAO();
-    m_buffer->drawIndexed(getNumOfIndices());
-    m_buffer->unbindVAO();
+    if (s_gpuDraw && m_gpuCache) {
+        s_gpuDraw(*m_gpuCache, getNumOfIndices(), 0);
+    }
 }
 
 void Plane::setData() {

--- a/Geometries/primitives.cpp
+++ b/Geometries/primitives.cpp
@@ -1,7 +1,17 @@
 #include "primitives.hpp"
 
+void (*Primitive::s_gpuBuild)(Primitive&, PrimitiveGPU*&) = nullptr;
+void (*Primitive::s_gpuFree)(PrimitiveGPU*) = nullptr;
+void (*Primitive::s_gpuDraw)(PrimitiveGPU&, unsigned, unsigned) = nullptr;
+void (*Primitive::s_gpuDrawInstanced)(PrimitiveGPU&, unsigned, unsigned, int) = nullptr;
+
 Primitive::Primitive() {}
-Primitive::~Primitive() {}
+
+Primitive::~Primitive() {
+    if (s_gpuFree && m_gpuCache) {
+        s_gpuFree(m_gpuCache);
+    }
+}
 
 void Primitive::set(const PrimitiveVertex* vertices, unsigned numOfvert, const uint32_t* indices, unsigned numOfindices) {
     for (size_t i = 0; i < numOfvert;    i++) m_vertex.push_back(vertices[i]);
@@ -27,17 +37,7 @@ void Primitive::setTexture(const std::string& pathToTexture) {
 }
 
 void Primitive::InitGraphics() {
-    m_buffer = GPUBuffer::create();
-
-    m_buffer->genVAO();
-    m_buffer->bindVAO();
-
-    m_buffer->create(BufferType::Vertex, getVertices(), sizeOfVertices());
-
-    if (getNumOfIndices() > 0)
-        m_buffer->create(BufferType::Index, getIndices(), sizeOfIndices());
-
-    m_buffer->applyFormat(PrimitiveVertex::getFormat());
-
-    m_buffer->unbindVAO();
+    if (s_gpuBuild && !m_gpuCache) {
+        s_gpuBuild(*this, m_gpuCache);
+    }
 }

--- a/Geometries/primitives.hpp
+++ b/Geometries/primitives.hpp
@@ -1,10 +1,8 @@
 #if !defined(_GEOMETRIES_H_)
 #define _GEOMETRIES_H_
 #include <vector>
-#include <memory>
 #include "../include/glmath.hpp"
 #include "../Textures/textures.hpp"
-#include "../GraphicsRenderBackend/gpu_buffer.hpp"
 #include "../GraphicsRenderBackend/vertex_format.hpp"
 #include "Shaders/shader.hpp"
 
@@ -16,13 +14,15 @@ struct PrimitiveVertex {
     FUNGT_VERTEX_FORMAT(PrimitiveVertex, position, normal, texcoord)
 };
 
+class PrimitiveGPU;
+
 class Primitive {
 private:
     std::vector<PrimitiveVertex> m_vertex;
     std::vector<uint32_t>        m_index;
 
 protected:
-    std::unique_ptr<GPUBuffer> m_buffer;
+    PrimitiveGPU* m_gpuCache = nullptr;
 
 public:
     Texture texture;
@@ -50,6 +50,11 @@ public:
 
     virtual void InstancedDraw(Shader& shader, int instanceCount) {}
     virtual void draw() = 0;
+
+    static void (*s_gpuBuild)(Primitive&, PrimitiveGPU*&);
+    static void (*s_gpuFree)(PrimitiveGPU*);
+    static void (*s_gpuDraw)(PrimitiveGPU&, unsigned indexCount, unsigned vertexCount);
+    static void (*s_gpuDrawInstanced)(PrimitiveGPU&, unsigned indexCount, unsigned vertexCount, int instanceCount);
 };
 
 #endif // _GEOMETRIES_H_

--- a/Geometries/pyramid.cpp
+++ b/Geometries/pyramid.cpp
@@ -10,9 +10,9 @@ Pyramid::~Pyramid()
 
 void Pyramid::draw() {
     texture.active();
-    m_buffer->bindVAO();
-    m_buffer->drawArrays(getNumOfVertices());
-    m_buffer->unbindVAO();
+    if (s_gpuDraw && m_gpuCache) {
+        s_gpuDraw(*m_gpuCache, 0, getNumOfVertices());
+    }
 }
 
 void Pyramid::setData()

--- a/Geometries/sphere.cpp
+++ b/Geometries/sphere.cpp
@@ -17,16 +17,16 @@ geometry::Sphere::~Sphere() {
 
 void geometry::Sphere::draw() {
     texture.active();
-    m_buffer->bindVAO();
-    m_buffer->drawIndexed(getNumOfIndices());
-    m_buffer->unbindVAO();
+    if (s_gpuDraw && m_gpuCache) {
+        s_gpuDraw(*m_gpuCache, getNumOfIndices(), 0);
+    }
 }
 
 void geometry::Sphere::InstancedDraw(Shader& shader, int instanceCount) {
     texture.active();
-    m_buffer->bindVAO();
-    m_buffer->drawIndexedInstanced(getNumOfIndices(), instanceCount);
-    m_buffer->unbindVAO();
+    if (s_gpuDrawInstanced && m_gpuCache) {
+        s_gpuDrawInstanced(*m_gpuCache, getNumOfIndices(), 0, instanceCount);
+    }
 }
 void geometry::Sphere::setData() {
     std::cout << "Calling Sphere::setData() " << std::endl;

--- a/Geometries/square.cpp
+++ b/Geometries/square.cpp
@@ -9,9 +9,9 @@ Square::~Square(){
 
 void Square::draw() {
     texture.active();
-    m_buffer->bindVAO();
-    m_buffer->drawIndexed(getNumOfIndices());
-    m_buffer->unbindVAO();
+    if (s_gpuDraw && m_gpuCache) {
+        s_gpuDraw(*m_gpuCache, getNumOfIndices(), 0);
+    }
 }
 
 void Square::setData()

--- a/GraphicsRenderBackend/gpu_texture.hpp
+++ b/GraphicsRenderBackend/gpu_texture.hpp
@@ -6,15 +6,8 @@
 #include <vector>
 #include <cstdint>
 #include "../Renders/display_graphics.hpp"
+#include "texture_enums.hpp"
 
-enum class TextureType {
-    Texture2D,
-    CubeMap
-};
-enum class TextureColorSpace {
-    Linear,
-    SRGB
-};
 class GPUTexture {
 public:
     virtual ~GPUTexture() = default;

--- a/GraphicsRenderBackend/texture_enums.hpp
+++ b/GraphicsRenderBackend/texture_enums.hpp
@@ -1,0 +1,14 @@
+#if !defined(_TEXTURE_ENUMS_HPP_)
+#define _TEXTURE_ENUMS_HPP_
+
+enum class TextureType {
+    Texture2D,
+    CubeMap
+};
+
+enum class TextureColorSpace {
+    Linear,
+    SRGB
+};
+
+#endif // _TEXTURE_ENUMS_HPP_

--- a/Mesh/mesh.cpp
+++ b/Mesh/mesh.cpp
@@ -1,5 +1,9 @@
 #include "mesh.hpp"
 
+void (*Mesh::s_gpuCacheBuild)(Mesh&) = nullptr;
+void (*Mesh::s_gpuCacheFree)(MeshGPU*) = nullptr;
+void (*Mesh::s_gpuCacheDraw)(MeshGPU&, size_t) = nullptr;
+
 Mesh::Mesh(){
     std::cout<<"Mesh Default Destructor"<<std::endl; 
 }
@@ -20,26 +24,21 @@ Mesh::Mesh(const std::vector<funGTVERTEX>& inVertex,
     m_material{inMaterial} {}
 Mesh::~Mesh()
 {
+    if (s_gpuCacheFree && m_gpuCache) {
+        s_gpuCacheFree(m_gpuCache);
+    }
     std::cout<<"Mesh Destructor"<<std::endl;
 }
 //Methods
-void Mesh::initMesh() {
-    m_buffer = GPUBuffer::create();
-
-    m_buffer->genVAO();
-    m_buffer->bindVAO();
-
-    m_buffer->create(BufferType::Vertex, m_vertex.data(), m_vertex.size() * sizeof(funGTVERTEX));
-    m_buffer->create(BufferType::Index,  m_index.data(),  m_index.size()  * sizeof(unsigned int));
-
-    // layout baked into the VAO once
-    m_buffer->applyFormat(funGTVERTEX::getFormat());
-
-    m_buffer->unbindVAO();
+void Mesh::attachGPUCache(MeshGPU* cache)
+{
+    m_gpuCache = cache;
 }
 void Mesh::InitOGLBuffers()
 {
-    initMesh();
+    if (s_gpuCacheBuild && !m_gpuCache) {
+        s_gpuCacheBuild(*this);
+    }
 }
 void Mesh::draw(Shader &shader){
 
@@ -47,7 +46,7 @@ void Mesh::draw(Shader &shader){
 
     unsigned int diffuseL = 1;
     unsigned int specularL = 1;
-    // ADD THIS LINE HERE:
+  
     shader.setUniform1i("hasTexture", numOfTextures > 0 ? 1 : 0);
     shader.set1i(0, "texture_diffuse1"); // keep this sampler pinned to unit 0 even when unused
     //std::cout<<"This mesh contains : "<< numOfTextures<<std::endl; 
@@ -70,9 +69,9 @@ void Mesh::draw(Shader &shader){
 
     }
 
-    m_buffer->bindVAO();
-    m_buffer->drawIndexed((m_index.size() / 3) * 3);
-    m_buffer->unbindVAO();
+    if (s_gpuCacheDraw && m_gpuCache) {
+        s_gpuCacheDraw(*m_gpuCache, m_index.size());
+    }
 
 }
 

--- a/Mesh/mesh.hpp
+++ b/Mesh/mesh.hpp
@@ -11,7 +11,7 @@
 #include "../include/prerequisites.hpp"
 #include "../Textures/textures.hpp"
 #include "../Material/material.hpp"
-#include "../GraphicsRenderBackend/gpu_buffer.hpp"
+#include <cstddef>
 #include <memory>
 #define ARRAY_SIZE_IN_ELEMENTS(a) (sizeof(a)/sizeof(a[0]))
 #define ASSIMP_LOAD_FLAGS (aiProcess_Triangulate | aiProcess_GenSmoothNormals | aiProcess_JoinIdenticalVertices)
@@ -20,6 +20,8 @@ struct Texture_struct {
     std::string type;
     std::string path;
 };
+
+class MeshGPU;
 
 class Mesh {
 
@@ -30,8 +32,7 @@ public:
     std::vector<Texture> m_texture; //An array of texturesç
     std::vector<Material> m_material;
 private:
-    std::unique_ptr<GPUBuffer> m_buffer; // owns VAO + VBO + EBO
-
+    MeshGPU* m_gpuCache = nullptr; 
 public:
     Mesh();
     Mesh(const std::vector<funGTVERTEX>& inVertex, const std::vector<uint32_t>& inIndex, std::vector<Texture> inTexture);
@@ -39,11 +40,18 @@ public:
     Mesh(const std::vector<funGTVERTEX>& inVertex,
         const std::vector<uint32_t>& inIndex,
         std::vector<Texture> inTexture,
-        const std::vector<Material>& inMaterial);  // takes texture by value — move into it
+        const std::vector<Material>& inMaterial);  // takes texture by value, moves into it
     ~Mesh();
-    void initMesh();
     void InitOGLBuffers();
     void draw(Shader& shader);
+
+    // Called by a registered s_gpuCacheBuild implementation only.
+    void attachGPUCache(MeshGPU* cache);
+
+    // Null until a raster backend calls RegisterMeshGPUCallbacks().
+    static void (*s_gpuCacheBuild)(Mesh&);
+    static void (*s_gpuCacheFree)(MeshGPU*);
+    static void (*s_gpuCacheDraw)(MeshGPU&, size_t indexCount);
 
 };
 

--- a/MeshGPU/mesh_gpu.cpp
+++ b/MeshGPU/mesh_gpu.cpp
@@ -1,0 +1,40 @@
+#include "mesh_gpu.hpp"
+#include "../Mesh/mesh.hpp"
+
+void BuildMeshGPU(Mesh& mesh)
+{
+    auto* cache = new MeshGPU();
+
+    cache->m_buffer = GPUBuffer::create();
+    cache->m_buffer->genVAO();
+    cache->m_buffer->bindVAO();
+
+    cache->m_buffer->create(BufferType::Vertex, mesh.m_vertex.data(),
+                             mesh.m_vertex.size() * sizeof(funGTVERTEX));
+    cache->m_buffer->create(BufferType::Index, mesh.m_index.data(),
+                             mesh.m_index.size() * sizeof(unsigned int));
+
+    cache->m_buffer->applyFormat(funGTVERTEX::getFormat());
+    cache->m_buffer->unbindVAO();
+
+    mesh.attachGPUCache(cache);
+}
+
+void FreeMeshGPU(MeshGPU* cache)
+{
+    delete cache;
+}
+
+void DrawMeshGPU(MeshGPU& cache, size_t indexCount)
+{
+    cache.m_buffer->bindVAO();
+    cache.m_buffer->drawIndexed((indexCount / 3) * 3);
+    cache.m_buffer->unbindVAO();
+}
+
+void RegisterMeshGPUCallbacks()
+{
+    Mesh::s_gpuCacheBuild = &BuildMeshGPU;
+    Mesh::s_gpuCacheFree  = &FreeMeshGPU;
+    Mesh::s_gpuCacheDraw  = &DrawMeshGPU;
+}

--- a/MeshGPU/mesh_gpu.hpp
+++ b/MeshGPU/mesh_gpu.hpp
@@ -1,0 +1,14 @@
+#if !defined(_MESH_GPU_HPP_)
+#define _MESH_GPU_HPP_
+#include <memory>
+#include "../GraphicsRenderBackend/gpu_buffer.hpp"
+
+class MeshGPU {
+public:
+    std::unique_ptr<GPUBuffer> m_buffer;
+};
+
+
+void RegisterMeshGPUCallbacks();
+
+#endif // _MESH_GPU_HPP_

--- a/Model/model.cpp
+++ b/Model/model.cpp
@@ -5,8 +5,10 @@ std::string Model::s_defaultVertexShader = "";
 std::string Model::s_defaultFragmentShader = "";
 bool Model::s_defaultShadersInitialized = false;
 
+Shader* (*Model::s_shaderCreate)() = nullptr;
+void (*Model::s_shaderFree)(Shader*) = nullptr;
+
 Model::Model()
-    : m_shader(Shader::create())
 {
     std::cout<<"Model Default Constructor"<<std::endl;
 }
@@ -18,9 +20,10 @@ Model::Model(const std::string &path)
    
 }
 Model::~Model(){
-
-    std::cout<<"Model Destructor"<<std::endl; 
-
+    if (s_shaderFree && m_shaderCache) {
+        s_shaderFree(m_shaderCache);
+    }
+    std::cout<<"Model Destructor"<<std::endl;
 }
 
 //Methods:
@@ -232,19 +235,24 @@ void Model::processAssimpScene(aiNode *node, const aiScene *scene)
 
 void Model::createShader(std::string vertex_shader, std::string fragment_shader)
 {
+    if (!s_shaderCreate) return;
+
+    if (!m_shaderCache) {
+        m_shaderCache = s_shaderCreate();
+    }
+
     if (!s_defaultShadersInitialized) {
         initializeDefaultShaders();
     }
 
     if (vertex_shader.empty() || fragment_shader.empty()) {
         std::cout << "Using default FunGT shader" << std::endl;
-        m_shader->create(s_defaultVertexShader, s_defaultFragmentShader);
+        m_shaderCache->create(s_defaultVertexShader, s_defaultFragmentShader);
     }
     else {
         std::cout << "Using custom shader" << std::endl;
-        m_shader->create(vertex_shader, fragment_shader);
+        m_shaderCache->create(vertex_shader, fragment_shader);
     }
-   
 }
 
 const std::vector<std::unique_ptr<Mesh>>& Model::getMeshes()
@@ -254,10 +262,10 @@ const std::vector<std::unique_ptr<Mesh>>& Model::getMeshes()
 
 void Model::draw()
 {
-      //std::cout<<"Drawing a Model "<<std::endl; 
+    if (!m_shaderCache) return;
     for(unsigned int i=0; i<m_vMesh.size(); i++){
-        m_vMesh[i]->draw(*m_shader);
-    }   
+        m_vMesh[i]->draw(*m_shaderCache);
+    }
 }
 
 std::unique_ptr<Mesh> Model::processMesh(aiMesh *mesh, const aiScene *scene)
@@ -422,7 +430,10 @@ void Model::setDirPath(const std::string &dirPath)
 }
 Shader &Model::getShader()
 {
-    return *m_shader;
+    if (!m_shaderCache) {
+        throw std::runtime_error("Shader not created. Call createShader() first.");
+    }
+    return *m_shaderCache;
 }
 const std::string &Model::getDirPath() const
 {

--- a/Model/model.hpp
+++ b/Model/model.hpp
@@ -39,10 +39,14 @@ class Model  {
         
     protected:
     //Members
-        std::vector<std::unique_ptr<Mesh>> m_vMesh; 
-        std::string m_dirPath; 
+        std::vector<std::unique_ptr<Mesh>> m_vMesh;
+        std::string m_dirPath;
         std::vector<Texture> m_loadedTextures;
-        std::unique_ptr<Shader> m_shader;
+        Shader* m_shaderCache = nullptr;
+
+    public:
+        static Shader* (*s_shaderCreate)();
+        static void (*s_shaderFree)(Shader*);
     
     private:
        

--- a/PBR/main/CMakeLists.txt
+++ b/PBR/main/CMakeLists.txt
@@ -147,15 +147,12 @@ set(PBR_CORE_FILES
     ${FUNGT_BASE_DIR}/PBR/Render/src/compute_backends.cpp
     ${FUNGT_BASE_DIR}/PBR/Render/src/cpu_renderer.cpp
     ${FUNGT_BASE_DIR}/Material/material.cpp
-    ${FUNGT_BASE_DIR}/Shaders/shader.cpp
-    ${FUNGT_BASE_DIR}/Shaders/opengl/opengl_shader.cpp
     ${FUNGT_BASE_DIR}/Random/random.cpp
     ${FUNGT_BASE_DIR}/Geometries/cube.cpp
     ${FUNGT_BASE_DIR}/Geometries/plane.cpp
     ${FUNGT_BASE_DIR}/Geometries/primitives.cpp
     ${FUNGT_BASE_DIR}/Geometries/pyramid.cpp
     ${FUNGT_BASE_DIR}/Geometries/shape.cpp
-    ${FUNGT_BASE_DIR}/Geometries/inf_grid.cpp
     ${FUNGT_BASE_DIR}/Geometries/square.cpp
     ${FUNGT_BASE_DIR}/Geometries/sphere.cpp
     ${FUNGT_BASE_DIR}/Geometries/box.cpp
@@ -166,20 +163,9 @@ set(PBR_CORE_FILES
     ${FUNGT_BASE_DIR}/Mesh/mesh.cpp
     ${FUNGT_BASE_DIR}/Textures/textures.cpp
     ${FUNGT_BASE_DIR}/vendor/stb_image/stb_image.cpp
-    ${FUNGT_BASE_DIR}/VertexGL/vertexArrayObjects.cpp
-    ${FUNGT_BASE_DIR}/VertexGL/vertexBuffers.cpp
-    ${FUNGT_BASE_DIR}/VertexGL/vertexIndices.cpp
-    ${FUNGT_BASE_DIR}/VertexGL/uniform_buffer_object.cpp
-    ${FUNGT_BASE_DIR}/VertexGL/shaderStorageBufferObejct.cpp
     ${FUNGT_BASE_DIR}/Matrix/matrix4x4f.cpp
     ${FUNGT_BASE_DIR}/Matrix/matrix3x3f.cpp
     ${FUNGT_BASE_DIR}/Renders/display_graphics.cpp
-    ${FUNGT_BASE_DIR}/GraphicsRenderBackend/graphics_render_device.cpp
-    ${FUNGT_BASE_DIR}/GraphicsRenderBackend/gpu_buffer.cpp
-    ${FUNGT_BASE_DIR}/GraphicsRenderBackend/gpu_texture.cpp
-    ${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl/opengl_device.cpp
-    ${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl/opengl_buffer.cpp
-    ${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl/opengl_texture.cpp
 )
 
 add_library(pbr_core STATIC ${PBR_CORE_FILES})
@@ -267,12 +253,6 @@ if(FUNGT_USE_SYCL)
         ${FUNLIB_DIR}/include
     )
 
-    target_link_libraries(pbr_sycl PRIVATE
-        OpenGL::GL
-        GLEW::GLEW
-        glfw
-    )
-
     target_compile_options(pbr_sycl PRIVATE -fsycl -fsycl-targets=${SYCL_TARGETS} ${SYCL_CUDA_ARCH_ARGS})
     target_link_options(pbr_sycl PRIVATE -fsycl -fsycl-targets=${SYCL_TARGETS} ${SYCL_CUDA_ARCH_ARGS})
 
@@ -321,32 +301,18 @@ else()
     endif()
 endif()
 
-find_package(OpenGL REQUIRED)
-if(OpenGL_FOUND)
-    message(STATUS "OpenGL found")
-else()
-    message(FATAL_ERROR "OpenGL library not found!")
-endif()
-
-find_package(glfw3 REQUIRED)
-if(glfw3_FOUND)
-    message(STATUS "GLFW found")
-else()
-    message(FATAL_ERROR "GLFW library not found!")
-endif()
-
-find_package(GLEW REQUIRED)
-if(GLEW_FOUND)
-    message(STATUS "GLEW found")
-else()
-    message(FATAL_ERROR "GLEW library not found!")
-endif()
-
 find_package(assimp REQUIRED)
 if(assimp_FOUND)
     message(STATUS "Assimp found")
 else()
     message(FATAL_ERROR "Assimp library not found!")
+endif()
+
+find_package(OpenGL REQUIRED)
+if(OpenGL_FOUND)
+    message(STATUS "OpenGL found (for GL/SYCL interop)")
+else()
+    message(FATAL_ERROR "OpenGL library not found!")
 endif()
 
 # ────────────────────────────────────────────────────────
@@ -383,8 +349,6 @@ target_link_libraries(pbr_render PRIVATE
     $<$<BOOL:${FUNGT_USE_CUDA}>:pbr_cuda>
     $<$<BOOL:${FUNGT_USE_SYCL}>:pbr_sycl>
     OpenGL::GL
-    glfw
-    GLEW::GLEW
     assimp::assimp
     funlib
     dl

--- a/PrimitiveGPU/primitive_gpu.cpp
+++ b/PrimitiveGPU/primitive_gpu.cpp
@@ -1,0 +1,50 @@
+#include "primitive_gpu.hpp"
+#include "../Geometries/primitives.hpp"
+
+void BuildPrimitiveGPU(Primitive& prim, PrimitiveGPU*& cache) {
+    cache = new PrimitiveGPU();
+    cache->m_buffer = GPUBuffer::create();
+
+    cache->m_buffer->genVAO();
+    cache->m_buffer->bindVAO();
+
+    cache->m_buffer->create(BufferType::Vertex, prim.getVertices(), prim.sizeOfVertices());
+
+    if (prim.getNumOfIndices() > 0)
+        cache->m_buffer->create(BufferType::Index, prim.getIndices(), prim.sizeOfIndices());
+
+    cache->m_buffer->applyFormat(PrimitiveVertex::getFormat());
+
+    cache->m_buffer->unbindVAO();
+}
+
+void FreePrimitiveGPU(PrimitiveGPU* cache) {
+    delete cache;
+}
+
+void DrawPrimitiveGPU(PrimitiveGPU& cache, unsigned indexCount, unsigned vertexCount) {
+    cache.m_buffer->bindVAO();
+    if (indexCount > 0) {
+        cache.m_buffer->drawIndexed(indexCount);
+    } else {
+        cache.m_buffer->drawArrays(vertexCount);
+    }
+    cache.m_buffer->unbindVAO();
+}
+
+void DrawPrimitiveGPUInstanced(PrimitiveGPU& cache, unsigned indexCount, unsigned vertexCount, int instanceCount) {
+    cache.m_buffer->bindVAO();
+    if (indexCount > 0) {
+        cache.m_buffer->drawIndexedInstanced(indexCount, instanceCount);
+    } else {
+        cache.m_buffer->drawArraysInstanced(vertexCount, instanceCount);
+    }
+    cache.m_buffer->unbindVAO();
+}
+
+void RegisterPrimitiveGPUCallbacks() {
+    Primitive::s_gpuBuild = &BuildPrimitiveGPU;
+    Primitive::s_gpuFree = &FreePrimitiveGPU;
+    Primitive::s_gpuDraw = &DrawPrimitiveGPU;
+    Primitive::s_gpuDrawInstanced = &DrawPrimitiveGPUInstanced;
+}

--- a/PrimitiveGPU/primitive_gpu.hpp
+++ b/PrimitiveGPU/primitive_gpu.hpp
@@ -1,0 +1,13 @@
+#if !defined(_PRIMITIVE_GPU_HPP_)
+#define _PRIMITIVE_GPU_HPP_
+#include <memory>
+#include "../GraphicsRenderBackend/gpu_buffer.hpp"
+
+class PrimitiveGPU {
+public:
+    std::unique_ptr<GPUBuffer> m_buffer;
+};
+
+void RegisterPrimitiveGPUCallbacks();
+
+#endif // _PRIMITIVE_GPU_HPP_

--- a/Samples/GUI/physics_controllers/CMakeLists.txt
+++ b/Samples/GUI/physics_controllers/CMakeLists.txt
@@ -223,6 +223,8 @@ include_directories(
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl
     ${FUNGT_BASE_DIR}/MeshGPU
+    ${FUNGT_BASE_DIR}/TextureGPU
+    ${FUNGT_BASE_DIR}/PrimitiveGPU
 )
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -246,6 +248,8 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/Material/material.cpp
     ${FUNGT_BASE_DIR}/Mesh/mesh.cpp
     ${FUNGT_BASE_DIR}/MeshGPU/mesh_gpu.cpp
+    ${FUNGT_BASE_DIR}/TextureGPU/texture_gpu.cpp
+    ${FUNGT_BASE_DIR}/PrimitiveGPU/primitive_gpu.cpp
     ${FUNGT_BASE_DIR}/Camera/camera.cpp
     ${FUNGT_BASE_DIR}/Geometries/cube.cpp
     ${FUNGT_BASE_DIR}/Geometries/plane.cpp

--- a/Samples/GUI/physics_controllers/CMakeLists.txt
+++ b/Samples/GUI/physics_controllers/CMakeLists.txt
@@ -222,6 +222,7 @@ include_directories(
     ${FUNGT_BASE_DIR}/IBL
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl
+    ${FUNGT_BASE_DIR}/MeshGPU
 )
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -244,6 +245,7 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/Imgui_Setup/imgui_setup.cpp
     ${FUNGT_BASE_DIR}/Material/material.cpp
     ${FUNGT_BASE_DIR}/Mesh/mesh.cpp
+    ${FUNGT_BASE_DIR}/MeshGPU/mesh_gpu.cpp
     ${FUNGT_BASE_DIR}/Camera/camera.cpp
     ${FUNGT_BASE_DIR}/Geometries/cube.cpp
     ${FUNGT_BASE_DIR}/Geometries/plane.cpp

--- a/Samples/hdr_test/CMakeLists.txt
+++ b/Samples/hdr_test/CMakeLists.txt
@@ -223,6 +223,8 @@ include_directories(
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl
     ${FUNGT_BASE_DIR}/MeshGPU
+    ${FUNGT_BASE_DIR}/TextureGPU
+    ${FUNGT_BASE_DIR}/PrimitiveGPU
 )
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -246,6 +248,8 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/Material/material.cpp
     ${FUNGT_BASE_DIR}/Mesh/mesh.cpp
     ${FUNGT_BASE_DIR}/MeshGPU/mesh_gpu.cpp
+    ${FUNGT_BASE_DIR}/TextureGPU/texture_gpu.cpp
+    ${FUNGT_BASE_DIR}/PrimitiveGPU/primitive_gpu.cpp
     ${FUNGT_BASE_DIR}/Camera/camera.cpp
     ${FUNGT_BASE_DIR}/Geometries/cube.cpp
     ${FUNGT_BASE_DIR}/Geometries/plane.cpp

--- a/Samples/hdr_test/CMakeLists.txt
+++ b/Samples/hdr_test/CMakeLists.txt
@@ -222,6 +222,7 @@ include_directories(
     ${FUNGT_BASE_DIR}/IBL
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl
+    ${FUNGT_BASE_DIR}/MeshGPU
 )
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -244,6 +245,7 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/Imgui_Setup/imgui_setup.cpp
     ${FUNGT_BASE_DIR}/Material/material.cpp
     ${FUNGT_BASE_DIR}/Mesh/mesh.cpp
+    ${FUNGT_BASE_DIR}/MeshGPU/mesh_gpu.cpp
     ${FUNGT_BASE_DIR}/Camera/camera.cpp
     ${FUNGT_BASE_DIR}/Geometries/cube.cpp
     ${FUNGT_BASE_DIR}/Geometries/plane.cpp

--- a/Samples/iwocl/CMakeLists.txt
+++ b/Samples/iwocl/CMakeLists.txt
@@ -222,6 +222,7 @@ include_directories(
     ${FUNGT_BASE_DIR}/IBL
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl
+    ${FUNGT_BASE_DIR}/MeshGPU
 )
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -234,6 +235,7 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/VertexGL/vertexBuffers.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexIndices.cpp
     ${FUNGT_BASE_DIR}/VertexGL/uniform_buffer_object.cpp
+    ${FUNGT_BASE_DIR}/VertexGL/shaderStorageBufferObejct.cpp
     ${FUNGT_BASE_DIR}/Shaders/shader.cpp
     ${FUNGT_BASE_DIR}/Shaders/opengl/opengl_shader.cpp
     ${FUNGT_BASE_DIR}/funGT/fungt.cpp
@@ -243,6 +245,7 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/Imgui_Setup/imgui_setup.cpp
     ${FUNGT_BASE_DIR}/Material/material.cpp
     ${FUNGT_BASE_DIR}/Mesh/mesh.cpp
+    ${FUNGT_BASE_DIR}/MeshGPU/mesh_gpu.cpp
     ${FUNGT_BASE_DIR}/Camera/camera.cpp
     ${FUNGT_BASE_DIR}/Geometries/cube.cpp
     ${FUNGT_BASE_DIR}/Geometries/plane.cpp

--- a/Samples/particle_simulation/CMakeLists.txt
+++ b/Samples/particle_simulation/CMakeLists.txt
@@ -6,6 +6,8 @@ project(FunGT)
 # ════════════════════════════════════════════════════════════════════════════
 option(FUNGT_USE_CUDA "Enable CUDA backend for NVIDIA GPUs" ON)
 option(FUNGT_USE_SYCL "Enable SYCL backend for Intel GPUs" ON)
+set(SYCL_CUDA_ARCH sm_75 CACHE STRING "NVIDIA GPU architecture for SYCL CUDA backend")
+set_property(CACHE SYCL_CUDA_ARCH PROPERTY STRINGS sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86 sm_87 sm_89 sm_90)
 
 # Allow FUNGT_BASE_DIR to be set externally (command line, environment, or cache)
 # Priority: 1. Cache variable, 2. Environment variable, 3. Default fallback
@@ -104,9 +106,6 @@ if(UNIX)
     set(CMAKE_BUILD_TYPE Release)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/release/linux)
     
-    # ALWAYS use SYCL compiler (required for funlib)
-    # set(CMAKE_CXX_COMPILER /home/juanchuletas/Documents/Development/FunGT/toolchain/sycl/linux_x64/dpcpp/bin/clang++)
-    
     # Add the prebuilt ImGui library
     add_library(imgui STATIC IMPORTED)
     set_target_properties(imgui PROPERTIES
@@ -169,6 +168,7 @@ include_directories(
     ${FUNGT_BASE_DIR}/AnimatedModel
     ${FUNGT_BASE_DIR}/Textures
     ${FUNGT_BASE_DIR}/vendor/stb_image
+    ${FUNGT_BASE_DIR}/vendor/glm/include
     ${FUNGT_BASE_DIR}/Imgui_Setup
     ${FUNGT_BASE_DIR}/Material
     ${FUNGT_BASE_DIR}/Mesh
@@ -219,6 +219,12 @@ include_directories(
     ${FUNGT_BASE_DIR}/Triangle
     ${FUNGT_BASE_DIR}/Gizmo/LightGizmo
     ${FUNGT_BASE_DIR}/Lights
+    ${FUNGT_BASE_DIR}/IBL
+    ${FUNGT_BASE_DIR}/GraphicsRenderBackend
+    ${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl
+    ${FUNGT_BASE_DIR}/MeshGPU
+    ${FUNGT_BASE_DIR}/TextureGPU
+    ${FUNGT_BASE_DIR}/PrimitiveGPU
 )
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -230,6 +236,8 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/VertexGL/vertexArrayObjects.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexBuffers.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexIndices.cpp
+    ${FUNGT_BASE_DIR}/VertexGL/uniform_buffer_object.cpp
+    ${FUNGT_BASE_DIR}/VertexGL/shaderStorageBufferObejct.cpp
     ${FUNGT_BASE_DIR}/Shaders/shader.cpp
     ${FUNGT_BASE_DIR}/Shaders/opengl/opengl_shader.cpp
     ${FUNGT_BASE_DIR}/funGT/fungt.cpp
@@ -239,6 +247,9 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/Imgui_Setup/imgui_setup.cpp
     ${FUNGT_BASE_DIR}/Material/material.cpp
     ${FUNGT_BASE_DIR}/Mesh/mesh.cpp
+    ${FUNGT_BASE_DIR}/MeshGPU/mesh_gpu.cpp
+    ${FUNGT_BASE_DIR}/TextureGPU/texture_gpu.cpp
+    ${FUNGT_BASE_DIR}/PrimitiveGPU/primitive_gpu.cpp
     ${FUNGT_BASE_DIR}/Camera/camera.cpp
     ${FUNGT_BASE_DIR}/Geometries/cube.cpp
     ${FUNGT_BASE_DIR}/Geometries/plane.cpp
@@ -257,23 +268,28 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/Matrix/matrix3x3f.cpp
     ${FUNGT_BASE_DIR}/SceneManager/scene_manager.cpp
     ${FUNGT_BASE_DIR}/CubeMap/cube_map.cpp
+    ${FUNGT_BASE_DIR}/IBL/ibl_probe.cpp
     ${FUNGT_BASE_DIR}/ParticleSimulation/particle_simulation.cpp
     ${FUNGT_BASE_DIR}/ParticleSimulation/particle_simulation_rtc.cpp
+    ${FUNGT_BASE_DIR}/ParticleSimulation/particle_simulation_sycl_ops.cpp
+    ${FUNGT_BASE_DIR}/ParticleSimulation/particle_rtc_sycl_ops.cpp
     ${FUNGT_BASE_DIR}/Random/random.cpp
     ${FUNGT_BASE_DIR}/Path_Manager/path_manager.cpp
     ${FUNGT_BASE_DIR}/InfoWindow/infowindow.cpp
     ${FUNGT_BASE_DIR}/GUI/gui.cpp
-    ${FUNGT_BASE_DIR}/GUI/particle_rtc_window.cpp
     ${FUNGT_BASE_DIR}/GUI/physics/simulation_controller_window.cpp
+    ${FUNGT_BASE_DIR}/GUI/demo_particles_window.cpp
+    ${FUNGT_BASE_DIR}/GUI/render_action_window.cpp
     ${FUNGT_BASE_DIR}/GUI/physics/debug_rigidbody_renderer.cpp
+    ${FUNGT_BASE_DIR}/GUI/particle_rtc_window.cpp
     ${FUNGT_BASE_DIR}/SimpleModel/simple_model.cpp
     ${FUNGT_BASE_DIR}/SimpleGeometry/simple_geometry.cpp
     ${FUNGT_BASE_DIR}/Physics/Collisions/simple_collision.cpp
     ${FUNGT_BASE_DIR}/Physics/Collisions/manifold_collision.cpp
     ${FUNGT_BASE_DIR}/Physics/CollisionManager/collision_manager.cpp
     ${FUNGT_BASE_DIR}/Physics/Collider/collider.cpp
-    ${FUNGT_BASE_DIR}/Physics/Clothing/clothing.cpp
     ${FUNGT_BASE_DIR}/Physics/AnimationCreator/key_frame_recorder.cpp
+    ${FUNGT_BASE_DIR}/Physics/AnimationCreator/animation_exporter.cpp
     ${FUNGT_BASE_DIR}/ViewPort/viewport.cpp
     ${FUNGT_BASE_DIR}/ViewPort/opengl/opengl_viewport.cpp
     ${FUNGT_BASE_DIR}/ViewPort/opengl/opengl_progressive_path_tracer.cpp
@@ -287,6 +303,12 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/PBR/BVH/bvh_builder.cpp
     ${FUNGT_BASE_DIR}/PBR/TriangleExtractor/triangle_extractor.cpp
     ${FUNGT_BASE_DIR}/Gizmo/LightGizmo/light_gizmo_renderer.cpp
+    ${FUNGT_BASE_DIR}/GraphicsRenderBackend/graphics_render_device.cpp
+    ${FUNGT_BASE_DIR}/GraphicsRenderBackend/gpu_buffer.cpp
+    ${FUNGT_BASE_DIR}/GraphicsRenderBackend/gpu_texture.cpp
+    ${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl/opengl_device.cpp
+    ${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl/opengl_buffer.cpp
+    ${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl/opengl_texture.cpp
 )
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -362,7 +384,6 @@ if (WIN32)
     find_package(GLEW REQUIRED)
     find_package(glfw3 REQUIRED)
     find_package(assimp REQUIRED)
-    find_package(glm REQUIRED)
     
     target_link_libraries(FunGT
         PRIVATE
@@ -370,7 +391,6 @@ if (WIN32)
         glfw
         GLEW::GLEW
         assimp::assimp
-        glm::glm
     )
     
 elseif (UNIX)
@@ -425,7 +445,12 @@ elseif (UNIX)
 
     endif()
 
-    
+    find_package(CURL REQUIRED)
+    if (CURL_FOUND)
+        message(STATUS "CURL found")
+    else()
+        message(FATAL_ERROR "CURL library not found!")
+    endif()
     find_package(OpenGL REQUIRED)
     if (OpenGL_FOUND)
         message(STATUS "OpenGL found")
@@ -454,22 +479,15 @@ elseif (UNIX)
         message(FATAL_ERROR "Assimp library not found!")
     endif()
     
-    find_package(glm CONFIG REQUIRED)
-    if(glm_FOUND)
-        message(STATUS "glm found")
-    else()
-        message(FATAL_ERROR "glm not found!")
-    endif()
-    
     # Link libraries
     target_include_directories(FunGT PRIVATE ${OpenCL_INCLUDE_DIRS})
     target_link_libraries(FunGT
         PRIVATE
+        CURL::libcurl
         OpenGL::GL
         glfw
         GLEW::GLEW
         assimp::assimp
-        glm::glm
         dl
         funlib
         imgui
@@ -478,21 +496,39 @@ elseif (UNIX)
         pbr_core                   
         ${PBR_CUDA_LIB}           
         ${PBR_SYCL_LIB} 
-        $<$<BOOL:${FUNGT_USE_CUDA}>:CUDA::cudart_static>  # CHANGE TO cudart_static
+        $<$<BOOL:${FUNGT_USE_CUDA}>:CUDA::cudart_static>
         $<$<BOOL:${FUNGT_USE_CUDA}>:CUDA::cuda_driver>           
     )
     
     # ════════════════════════════════════════════════════════════════════════
-    # SYCL compilation flags (always applied because funlib requires it)
+    # SYCL compilation flags (per-file, not blanket)
     # ════════════════════════════════════════════════════════════════════════
     if(CUDAToolkit_FOUND)
         message(STATUS "CUDA SYCL backend enabled")
         set(SYCL_TARGETS nvptx64-nvidia-cuda,spir64)
+        set(SYCL_CUDA_ARCH_ARGS
+            "-Xsycl-target-backend=nvptx64-nvidia-cuda"
+            "--offload-arch=${SYCL_CUDA_ARCH}"
+        )
     else()
         set(SYCL_TARGETS spir64)
+        set(SYCL_CUDA_ARCH_ARGS "")
     endif()
-    target_compile_options(FunGT PRIVATE -fsycl -fsycl-targets=${SYCL_TARGETS})
-    target_link_options(FunGT PRIVATE -fsycl -fsycl-targets=${SYCL_TARGETS})
+
+    set(SYCL_SOURCES
+        ${FUNGT_BASE_DIR}/InfoDevice/sycl_backend.cpp
+        ${FUNGT_BASE_DIR}/ParticleSimulation/particle_simulation_sycl_ops.cpp
+        ${FUNGT_BASE_DIR}/ParticleSimulation/particle_rtc_sycl_ops.cpp
+        ${FUNGT_BASE_DIR}/PBR/Space/space.cpp
+    )
+
+    list(JOIN SYCL_CUDA_ARCH_ARGS " " SYCL_CUDA_ARCH_STR)
+
+    set_source_files_properties(${SYCL_SOURCES}
+        PROPERTIES COMPILE_FLAGS "-fsycl -fsycl-targets=${SYCL_TARGETS} ${SYCL_CUDA_ARCH_STR}"
+    )
+
+    target_link_options(FunGT PRIVATE -fsycl -fsycl-targets=${SYCL_TARGETS} ${SYCL_CUDA_ARCH_ARGS})
     
     if(FUNGT_USE_SYCL)
         target_compile_definitions(FunGT PRIVATE FUNGT_USE_SYCL)

--- a/Samples/rtc_pSym/CMakeLists.txt
+++ b/Samples/rtc_pSym/CMakeLists.txt
@@ -219,8 +219,12 @@ include_directories(
     ${FUNGT_BASE_DIR}/Triangle
     ${FUNGT_BASE_DIR}/Gizmo/LightGizmo
     ${FUNGT_BASE_DIR}/Lights
+    ${FUNGT_BASE_DIR}/IBL
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend
     ${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl
+    ${FUNGT_BASE_DIR}/MeshGPU
+    ${FUNGT_BASE_DIR}/TextureGPU
+    ${FUNGT_BASE_DIR}/PrimitiveGPU
 )
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -232,6 +236,8 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/VertexGL/vertexArrayObjects.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexBuffers.cpp
     ${FUNGT_BASE_DIR}/VertexGL/vertexIndices.cpp
+    ${FUNGT_BASE_DIR}/VertexGL/uniform_buffer_object.cpp
+    ${FUNGT_BASE_DIR}/VertexGL/shaderStorageBufferObejct.cpp
     ${FUNGT_BASE_DIR}/Shaders/shader.cpp
     ${FUNGT_BASE_DIR}/Shaders/opengl/opengl_shader.cpp
     ${FUNGT_BASE_DIR}/funGT/fungt.cpp
@@ -241,6 +247,9 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/Imgui_Setup/imgui_setup.cpp
     ${FUNGT_BASE_DIR}/Material/material.cpp
     ${FUNGT_BASE_DIR}/Mesh/mesh.cpp
+    ${FUNGT_BASE_DIR}/MeshGPU/mesh_gpu.cpp
+    ${FUNGT_BASE_DIR}/TextureGPU/texture_gpu.cpp
+    ${FUNGT_BASE_DIR}/PrimitiveGPU/primitive_gpu.cpp
     ${FUNGT_BASE_DIR}/Camera/camera.cpp
     ${FUNGT_BASE_DIR}/Geometries/cube.cpp
     ${FUNGT_BASE_DIR}/Geometries/plane.cpp
@@ -259,6 +268,7 @@ set(SOURCE_FILES
     ${FUNGT_BASE_DIR}/Matrix/matrix3x3f.cpp
     ${FUNGT_BASE_DIR}/SceneManager/scene_manager.cpp
     ${FUNGT_BASE_DIR}/CubeMap/cube_map.cpp
+    ${FUNGT_BASE_DIR}/IBL/ibl_probe.cpp
     ${FUNGT_BASE_DIR}/ParticleSimulation/particle_simulation.cpp
     ${FUNGT_BASE_DIR}/ParticleSimulation/particle_simulation_rtc.cpp
     ${FUNGT_BASE_DIR}/ParticleSimulation/particle_simulation_sycl_ops.cpp

--- a/TextureGPU/texture_gpu.cpp
+++ b/TextureGPU/texture_gpu.cpp
@@ -1,0 +1,57 @@
+#include "texture_gpu.hpp"
+#include "../Textures/textures.hpp"
+
+TextureGPU* BuildTextureGPU(TextureType type) {
+    auto* cache = new TextureGPU();
+    cache->m_gpu = GPUTexture::create(type);
+    return cache;
+}
+
+void FreeTextureGPU(TextureGPU* cache) {
+    delete cache;
+}
+
+void UploadTextureGPU(TextureGPU& cache, const unsigned char* pixels, int w, int h, TextureColorSpace cs) {
+    cache.m_gpu->upload(pixels, w, h, cs);
+}
+
+void UploadFloatTextureGPU(TextureGPU& cache, const float* pixels, int w, int h) {
+    cache.m_gpu->uploadFloat(pixels, w, h);
+}
+
+void UploadCubeMapTextureGPU(TextureGPU& cache, const std::vector<unsigned char*>& faces, int w, int h) {
+    cache.m_gpu->uploadCubeMap(faces, w, h);
+}
+
+void AllocateEmptyCubemapTextureGPU(TextureGPU& cache, int faceSize, bool mipmaps) {
+    cache.m_gpu->allocateEmptyCubemap(faceSize, mipmaps);
+}
+
+void BindTextureGPU(TextureGPU& cache, unsigned int slot) {
+    cache.m_gpu->bind(slot);
+}
+
+void UnbindTextureGPU(TextureGPU& cache) {
+    cache.m_gpu->unbind();
+}
+
+void DestroyTextureGPU(TextureGPU& cache) {
+    cache.m_gpu->destroy();
+}
+
+uint32_t GetIDTextureGPU(const TextureGPU& cache) {
+    return cache.m_gpu ? cache.m_gpu->getID() : 0;
+}
+
+void RegisterTextureGPUCallbacks() {
+    Texture::s_gpuCreate = &BuildTextureGPU;
+    Texture::s_gpuFree = &FreeTextureGPU;
+    Texture::s_gpuUpload = &UploadTextureGPU;
+    Texture::s_gpuUploadFloat = &UploadFloatTextureGPU;
+    Texture::s_gpuUploadCubeMap = &UploadCubeMapTextureGPU;
+    Texture::s_gpuAllocateEmptyCubemap = &AllocateEmptyCubemapTextureGPU;
+    Texture::s_gpuBind = &BindTextureGPU;
+    Texture::s_gpuUnbind = &UnbindTextureGPU;
+    Texture::s_gpuDestroy = &DestroyTextureGPU;
+    Texture::s_gpuGetID = &GetIDTextureGPU;
+}

--- a/TextureGPU/texture_gpu.hpp
+++ b/TextureGPU/texture_gpu.hpp
@@ -1,0 +1,13 @@
+#if !defined(_TEXTURE_GPU_HPP_)
+#define _TEXTURE_GPU_HPP_
+#include <memory>
+#include "../GraphicsRenderBackend/gpu_texture.hpp"
+
+class TextureGPU {
+public:
+    std::unique_ptr<GPUTexture> m_gpu;
+};
+
+void RegisterTextureGPUCallbacks();
+
+#endif // _TEXTURE_GPU_HPP_

--- a/Textures/textures.cpp
+++ b/Textures/textures.cpp
@@ -2,26 +2,81 @@
 #include "../vendor/stb_image/stb_image.h"
 #include <iostream>
 
-Texture::Texture()
-    : m_gpu(GPUTexture::create(TextureType::Texture2D)) {}
+TextureGPU* (*Texture::s_gpuCreate)(TextureType) = nullptr;
+void (*Texture::s_gpuFree)(TextureGPU*) = nullptr;
+void (*Texture::s_gpuUpload)(TextureGPU&, const unsigned char*, int, int, TextureColorSpace) = nullptr;
+void (*Texture::s_gpuUploadFloat)(TextureGPU&, const float*, int, int) = nullptr;
+void (*Texture::s_gpuUploadCubeMap)(TextureGPU&, const std::vector<unsigned char*>&, int, int) = nullptr;
+void (*Texture::s_gpuAllocateEmptyCubemap)(TextureGPU&, int, bool) = nullptr;
+void (*Texture::s_gpuBind)(TextureGPU&, unsigned int) = nullptr;
+void (*Texture::s_gpuUnbind)(TextureGPU&) = nullptr;
+void (*Texture::s_gpuDestroy)(TextureGPU&) = nullptr;
+uint32_t (*Texture::s_gpuGetID)(const TextureGPU&) = nullptr;
 
-Texture::Texture(TextureType type)
-    : m_gpu(GPUTexture::create(type)) {}
+Texture::Texture() {
+    if (s_gpuCreate) {
+        m_gpuCache = s_gpuCreate(TextureType::Texture2D);
+    }
+}
+
+Texture::Texture(TextureType type) {
+    if (s_gpuCreate) {
+        m_gpuCache = s_gpuCreate(type);
+    }
+}
 
 Texture::Texture(const std::string& path)
-    : txt_Path(path), m_gpu(GPUTexture::create(TextureType::Texture2D))
+    : txt_Path(path)
 {
+    if (s_gpuCreate) {
+        m_gpuCache = s_gpuCreate(TextureType::Texture2D);
+    }
     genTexture(path);
 }
 
 Texture::Texture(const std::string& path, TextureType type)
-    : txt_Path(path), m_gpu(GPUTexture::create(type))
+    : txt_Path(path)
 {
+    if (s_gpuCreate) {
+        m_gpuCache = s_gpuCreate(type);
+    }
     genTexture(path);
 }
 
 Texture::~Texture() {
+    if (s_gpuFree && m_gpuCache) {
+        s_gpuFree(m_gpuCache);
+    }
     std::cout << "Texture Destructor" << std::endl;
+}
+
+Texture::Texture(Texture&& other) noexcept
+    : name(std::move(other.name)),
+      m_type(std::move(other.m_type)),
+      txt_Path(std::move(other.txt_Path)),
+      txt_width(other.txt_width),
+      txt_height(other.txt_height),
+      txt_BBP(other.txt_BBP),
+      m_gpuCache(other.m_gpuCache)
+{
+    other.m_gpuCache = nullptr;
+}
+
+Texture& Texture::operator=(Texture&& other) noexcept {
+    if (this != &other) {
+        if (s_gpuFree && m_gpuCache) {
+            s_gpuFree(m_gpuCache);
+        }
+        name = std::move(other.name);
+        m_type = std::move(other.m_type);
+        txt_Path = std::move(other.txt_Path);
+        txt_width = other.txt_width;
+        txt_height = other.txt_height;
+        txt_BBP = other.txt_BBP;
+        m_gpuCache = other.m_gpuCache;
+        other.m_gpuCache = nullptr;
+    }
+    return *this;
 }
 
 void Texture::genTexture(const std::string& path, TextureColorSpace colorSpace) {
@@ -32,7 +87,9 @@ void Texture::genTexture(const std::string& path, TextureColorSpace colorSpace) 
     if (pixels) {
         std::cout << "\nOk to load: " << std::endl;
         printf("%s\n", txt_Path.c_str());
-        m_gpu->upload(pixels, txt_width, txt_height, colorSpace);
+        if (s_gpuUpload && m_gpuCache) {
+            s_gpuUpload(*m_gpuCache, pixels, txt_width, txt_height, colorSpace);
+        }
         stbi_image_free(pixels);
     } else {
         std::cout << "\nError: Failed to load texture" << std::endl;
@@ -48,7 +105,9 @@ void Texture::genTextureHDR(const std::string& path) {
     if (pixels) {
         std::cout << "\nOk to load HDR: " << std::endl;
         printf("%s\n", txt_Path.c_str());
-        m_gpu->uploadFloat(pixels, txt_width, txt_height);
+        if (s_gpuUploadFloat && m_gpuCache) {
+            s_gpuUploadFloat(*m_gpuCache, pixels, txt_width, txt_height);
+        }
         stbi_image_free(pixels);
     } else {
         std::cout << "\nError: Failed to load HDR texture" << std::endl;
@@ -57,8 +116,9 @@ void Texture::genTextureHDR(const std::string& path) {
 }
 
 void Texture::genTextureCubeMap(const std::vector<std::string>& faces) {
-    if (!m_gpu)
-        m_gpu = GPUTexture::create(TextureType::CubeMap);
+    if (!m_gpuCache && s_gpuCreate) {
+        m_gpuCache = s_gpuCreate(TextureType::CubeMap);
+    }
 
     std::vector<unsigned char*> pixelFaces;
     int w = 0, h = 0, bbp = 0;
@@ -76,34 +136,50 @@ void Texture::genTextureCubeMap(const std::vector<std::string>& faces) {
         pixelFaces.push_back(pixels);
     }
 
-    m_gpu->uploadCubeMap(pixelFaces, w, h);
+    if (s_gpuUploadCubeMap && m_gpuCache) {
+        s_gpuUploadCubeMap(*m_gpuCache, pixelFaces, w, h);
+    }
 
     for (auto* p : pixelFaces)
         if (p) stbi_image_free(p);
 }
 
 void Texture::allocateEmptyCubemap(int faceSize, bool mipmaps) {
-    if (!m_gpu)
-        m_gpu = GPUTexture::create(TextureType::CubeMap);
-    m_gpu->allocateEmptyCubemap(faceSize, mipmaps);
+    if (!m_gpuCache && s_gpuCreate) {
+        m_gpuCache = s_gpuCreate(TextureType::CubeMap);
+    }
+    if (s_gpuAllocateEmptyCubemap && m_gpuCache) {
+        s_gpuAllocateEmptyCubemap(*m_gpuCache, faceSize, mipmaps);
+    }
 }
 
 void Texture::active(unsigned int slot) {
-    m_gpu->bind(slot);
+    if (s_gpuBind && m_gpuCache) {
+        s_gpuBind(*m_gpuCache, slot);
+    }
 }
 
 void Texture::bind() {
-    m_gpu->bind();
+    if (s_gpuBind && m_gpuCache) {
+        s_gpuBind(*m_gpuCache, 0);
+    }
 }
 
 void Texture::unBind() {
-    m_gpu->unbind();
+    if (s_gpuUnbind && m_gpuCache) {
+        s_gpuUnbind(*m_gpuCache);
+    }
 }
 
 void Texture::Delete() {
-    m_gpu->destroy();
+    if (s_gpuDestroy && m_gpuCache) {
+        s_gpuDestroy(*m_gpuCache);
+    }
 }
 
 uint32_t Texture::getID() const {
-    return m_gpu ? m_gpu->getID() : 0;
+    if (s_gpuGetID && m_gpuCache) {
+        return s_gpuGetID(*m_gpuCache);
+    }
+    return 0;
 }

--- a/Textures/textures.hpp
+++ b/Textures/textures.hpp
@@ -2,8 +2,10 @@
 #define _TEXTURES_H_
 #include <vector>
 #include <string>
-#include <memory>
-#include "GraphicsRenderBackend/gpu_texture.hpp"
+#include <cstdint>
+#include "../GraphicsRenderBackend/texture_enums.hpp"
+
+class TextureGPU;
 
 class Texture {
 public:
@@ -13,7 +15,7 @@ public:
 private:
     std::string  txt_Path;
     int          txt_width = 0, txt_height = 0, txt_BBP = 0;
-    std::unique_ptr<GPUTexture> m_gpu;
+    TextureGPU*  m_gpuCache = nullptr;
 
 public:
     Texture();
@@ -22,12 +24,12 @@ public:
     Texture(const std::string& path, TextureType type);
     ~Texture();
 
-    Texture(Texture&&) = default;
-    Texture& operator=(Texture&&) = default;
+    Texture(Texture&& other) noexcept;
+    Texture& operator=(Texture&& other) noexcept;
     Texture(const Texture&) = delete;
     Texture& operator=(const Texture&) = delete;
 
-    void genTexture(const std::string& path, 
+    void genTexture(const std::string& path,
                     TextureColorSpace colorSpace = TextureColorSpace::SRGB);
     void genTextureHDR(const std::string& path);
     void genTextureCubeMap(const std::vector<std::string>& faces);
@@ -44,6 +46,17 @@ public:
     inline std::string getPath()         const         { return txt_Path; }
     inline void setTypeName(std::string textureType)   { m_type = textureType; }
     inline std::string getTypeName()     const         { return m_type; }
+
+    static TextureGPU* (*s_gpuCreate)(TextureType type);
+    static void (*s_gpuFree)(TextureGPU*);
+    static void (*s_gpuUpload)(TextureGPU&, const unsigned char*, int, int, TextureColorSpace);
+    static void (*s_gpuUploadFloat)(TextureGPU&, const float*, int, int);
+    static void (*s_gpuUploadCubeMap)(TextureGPU&, const std::vector<unsigned char*>&, int, int);
+    static void (*s_gpuAllocateEmptyCubemap)(TextureGPU&, int, bool);
+    static void (*s_gpuBind)(TextureGPU&, unsigned int);
+    static void (*s_gpuUnbind)(TextureGPU&);
+    static void (*s_gpuDestroy)(TextureGPU&);
+    static uint32_t (*s_gpuGetID)(const TextureGPU&);
 };
 
 #endif // _TEXTURES_H_

--- a/funGT/fungt.hpp
+++ b/funGT/fungt.hpp
@@ -10,6 +10,7 @@
 #include "Layer/layer_stack.hpp"              
 #include "GUI/fungt_gui_headers.hpp"
 #include "SimpleGeometry/simple_geometry.hpp"
+#include "ParticleSimulation/particle_simulation.hpp"
 #include "Physics/AnimationCreator/animation_controller.hpp"
 #include "Physics/PhysicsWorld/physics_world.hpp"
 #include "Gizmo/LightGizmo/light_gizmo_renderer.hpp"

--- a/resources/particle.vs
+++ b/resources/particle.vs
@@ -1,9 +1,19 @@
 #version 440
 layout (location = 0) in vec3 aPos;
-uniform mat4 ModelMatrix; 
-uniform mat4 ViewMatrix; 
-uniform mat4 ProjectionMatrix; 
+
+layout(std140, binding = 0) uniform Matrices {
+    mat4 ViewMatrix;
+    mat4 ProjectionMatrix;
+};
+
+layout(std430, binding = 2) readonly buffer ModelMatrices {
+    mat4 models[];
+};
+
+uniform int ModelMatrixIndex;
+
 void main() {
-    gl_Position = ProjectionMatrix*ViewMatrix*ModelMatrix*vec4(aPos, 1.0);
-    gl_PointSize = 3.0;// Size of the particle
+    mat4 ModelMatrix = models[ModelMatrixIndex];
+    gl_Position = ProjectionMatrix * ViewMatrix * ModelMatrix * vec4(aPos, 1.0);
+    gl_PointSize = 3.0;
 }


### PR DESCRIPTION

## Description

Model class is composed of a vector of Mesh class objects

```cpp
class Model{
        std::vector<std::unique_ptr<Mesh>> m_vMesh;
};

```
And the class mesh contained a member related with GPU buffers

```cpp
class Mesh {
    std::unique_ptr<GPUBuffer> m_buffer;  // needs full definition
};

```

GPUBuffer is an abstract class, but the factory method:


```cpp

std::unique_ptr<GPUBuffer> GPUBuffer::create() {
    switch (DisplayGraphics::GetBackend()) {
        case Backend::OpenGL:
            return std::make_unique<OpenGLBuffer>();  // instantiates concrete type
    }
}

```
builds the OpenGL related buffer object.

The main class ```Space```  of RaySpace path tracer needs Model objects in order to extract vertex data:


```cpp

void Space::LoadModelToRender(const SimpleModel& Simplemodel)
{
    Model& model = Simplemodel.getModel(); 
}

```

This currently creates a dependency of OpenGL buffers for the build process.

So PBR's CMakeLists had to include:

```console
${FUNGT_BASE_DIR}/GraphicsRenderBackend/gpu_buffer.cpp
${FUNGT_BASE_DIR}/GraphicsRenderBackend/opengl/opengl_buffer.cpp
# ... and link
OpenGL::GL
```

## Proposed changes


Replace compile-time dependency with runtime registration:

```cpp
// mesh.hpp  no GPU includes
class MeshGPU;  // forward declaration only

class Mesh {
    MeshGPU* m_gpuCache = nullptr;  // opaque pointer
    
    static void (*s_gpuBuild)(Mesh&);  // null by default
    static void (*s_gpuFree)(MeshGPU*);
};

// mesh.cpp no GPU includes
void Mesh::InitOGLBuffers() {
    if (s_gpuBuild && !m_gpuCache) {
        s_gpuBuild(*this);  // only runs if callback was registered
    }
}

Mesh::~Mesh() {
    if (s_gpuFree && m_gpuCache) {
        s_gpuFree(m_gpuCache);
    }
}

// mesh_gpu.cpp  contains GPU includes, that are only compiled by raster targets
void BuildMeshGPU(Mesh& mesh) {
    auto* cache = new MeshGPU();
    cache->m_buffer = GPUBuffer::create();  // OpenGL call happens HERE
    // ... upload vertex data ...
    mesh.attachGPUCache(cache);
}

void RegisterMeshGPUCallbacks() {
    Mesh::s_gpuBuild = &BuildMeshGPU;
    Mesh::s_gpuFree = &FreeMeshGPU;
}

```

## Type of Change
<!-- Mark with [x] -->
- [ ]  Bug fix (non-breaking change that fixes an issue)
- [ ]  New feature (non-breaking change that adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)
- [x]  Refactor (code change that neither fixes a bug nor adds a feature)
- [ ]  Documentation (changes to docs only)
- [ ]  Performance (improves performance)

